### PR TITLE
[Migration] Migrate ConnectWalletButton to shadcn registry (#4)

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -4,23 +4,22 @@
   "homepage": "https://w3-kit.com",
   "items": [
     {
-      "name": "@w3-kit/address-book",
+      "name": "@w3-kit/connect-wallet",
       "type": "registry:component",
-      "title": "Address Book",
-      "description": "A Web3 address book component with ENS support, search, and CRUD operations.",
-      "dependencies": ["lucide-react"],
-      "registryDependencies": ["button", "input", "card", "dialog", "textarea"],
+      "title": "Connect Wallet Button",
+      "description": "A multi-wallet connect button supporting MetaMask, WalletConnect, Coinbase Wallet, and Phantom (Solana).",
+      "dependencies": ["@web3-react/walletconnect-connector"],
       "files": [
         {
-          "path": "registry/w3-kit/address-book/address-book.tsx",
+          "path": "registry/w3-kit/connect-wallet/connect-wallet.tsx",
           "type": "registry:component"
         },
         {
-          "path": "registry/w3-kit/address-book/types.ts",
+          "path": "registry/w3-kit/connect-wallet/types.ts",
           "type": "registry:component"
         },
         {
-          "path": "registry/w3-kit/address-book/utils.ts",
+          "path": "registry/w3-kit/connect-wallet/utils.ts",
           "type": "registry:component"
         }
       ]

--- a/registry/w3-kit/connect-wallet/connect-wallet.tsx
+++ b/registry/w3-kit/connect-wallet/connect-wallet.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { ConnectWalletButtonProps, CoinbaseWalletProvider, SolanaProvider } from './types';
+import {
+  variantStyles,
+  DEFAULT_WALLETCONNECT_CONFIG,
+  WALLET_ICONS,
+  getDefaultLabel,
+  buttonAnimation,
+  spinnerAnimation,
+} from './utils';
+
+// Extend window interface for wallet providers
+declare global {
+  interface Window {
+    ethereum?: {
+      isMetaMask?: boolean;
+      request: (args: { method: string }) => Promise<string[]>;
+    };
+    coinbaseWalletExtension?: CoinbaseWalletProvider;
+    solana?: SolanaProvider;
+    phantom?: {
+      solana?: SolanaProvider;
+    };
+  }
+}
+
+// Phantom wallet icon as inline SVG
+const PhantomIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 128 128" fill="none">
+    <rect width="128" height="128" rx="64" fill="#AB9FF2"/>
+    <path d="M110.984 64.206C110.984 89.2476 90.7077 109.524 65.666 109.524C40.6244 109.524 20.3477 89.2476 20.3477 64.206C20.3477 39.1644 40.6244 18.8877 65.666 18.8877C90.7077 18.8877 110.984 39.1644 110.984 64.206Z" fill="white"/>
+  </svg>
+);
+
+// Loading spinner component
+const LoadingSpinner = () => (
+  <svg className={spinnerAnimation} viewBox="0 0 24 24">
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+      fill="none"
+    />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+    />
+  </svg>
+);
+
+export const ConnectWalletButton: React.FC<ConnectWalletButtonProps> = ({
+  onConnect,
+  onError,
+  className = '',
+  customLabel,
+  variant = 'dark',
+  walletType = 'metamask',
+  walletConnectConfig = DEFAULT_WALLETCONNECT_CONFIG,
+}) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const connectMetaMask = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (typeof window.ethereum === 'undefined') {
+        throw new Error('MetaMask is not installed');
+      }
+
+      if (!window.ethereum.isMetaMask) {
+        throw new Error('Please switch to MetaMask');
+      }
+
+      const accounts = await window.ethereum.request({
+        method: 'eth_requestAccounts'
+      });
+
+      if (accounts && Array.isArray(accounts) && accounts.length > 0) {
+        onConnect?.(accounts[0] as string);
+      } else {
+        throw new Error('No accounts found');
+      }
+    } catch (err) {
+      const error = err as Error;
+      setError(error.message);
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onConnect, onError]);
+
+  const connectWalletConnect = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Dynamic import to avoid bundling issues
+      const { WalletConnectConnector } = await import('@web3-react/walletconnect-connector');
+
+      const connector = new WalletConnectConnector({
+        rpc: walletConnectConfig.rpc,
+        bridge: walletConnectConfig.bridge,
+        qrcode: true,
+      });
+
+      await connector.activate();
+      const account = await connector.getAccount();
+      if (account) {
+        onConnect?.(account);
+      } else {
+        throw new Error('No account found');
+      }
+    } catch (err) {
+      const error = err as Error;
+      setError(error.message);
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onConnect, onError, walletConnectConfig]);
+
+  const connectCoinbase = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (!window.coinbaseWalletExtension) {
+        throw new Error('Coinbase Wallet is not installed');
+      }
+
+      const accounts = await window.coinbaseWalletExtension.request({
+        method: 'eth_requestAccounts'
+      });
+
+      if (accounts && Array.isArray(accounts) && accounts.length > 0) {
+        onConnect?.(accounts[0]);
+      } else {
+        throw new Error('No accounts found');
+      }
+    } catch (err) {
+      const error = err as Error;
+      setError(error.message);
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onConnect, onError]);
+
+  const connectPhantom = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (!window.phantom?.solana) {
+        throw new Error('Phantom wallet is not installed');
+      }
+
+      const response = await window.phantom.solana.connect();
+      const address = response.publicKey.toString();
+      onConnect?.(address);
+    } catch (err) {
+      const error = err as Error;
+      setError(error.message);
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onConnect, onError]);
+
+  const handleConnect = useCallback(() => {
+    switch (walletType) {
+      case 'metamask':
+        return connectMetaMask();
+      case 'walletconnect':
+        return connectWalletConnect();
+      case 'coinbase':
+        return connectCoinbase();
+      case 'phantom':
+        return connectPhantom();
+      default:
+        return connectMetaMask();
+    }
+  }, [walletType, connectMetaMask, connectWalletConnect, connectCoinbase, connectPhantom]);
+
+  const renderWalletIcon = () => {
+    if (walletType === 'phantom') {
+      return <PhantomIcon />;
+    }
+
+    const iconUrl = WALLET_ICONS[walletType];
+    return (
+      <img
+        src={iconUrl}
+        alt={walletType}
+        width={24}
+        height={24}
+        className="rounded-sm"
+      />
+    );
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <button
+        onClick={handleConnect}
+        disabled={isLoading}
+        className={`
+          px-6 py-3 rounded-xl font-medium
+          flex items-center justify-center min-w-[240px]
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${buttonAnimation}
+          ${variantStyles[variant]}
+          ${className}
+        `}
+      >
+        {isLoading ? (
+          <div className="flex items-center space-x-2">
+            <LoadingSpinner />
+            <span>Connecting...</span>
+          </div>
+        ) : (
+          <div className="flex items-center space-x-3">
+            <div className="w-6 h-6 flex items-center justify-center">
+              {renderWalletIcon()}
+            </div>
+            <span className="text-[15px]">{customLabel || getDefaultLabel(walletType)}</span>
+          </div>
+        )}
+      </button>
+      {error && (
+        <p className="mt-2 text-sm text-red-500 dark:text-red-400">{error}</p>
+      )}
+    </div>
+  );
+};

--- a/registry/w3-kit/connect-wallet/types.ts
+++ b/registry/w3-kit/connect-wallet/types.ts
@@ -1,0 +1,32 @@
+export type ButtonVariant = 'ghost' | 'light' | 'dark';
+export type WalletType = 'metamask' | 'walletconnect' | 'coinbase' | 'phantom';
+
+export interface ConnectWalletButtonProps {
+  onConnect?: (address: string) => void;
+  onError?: (error: Error) => void;
+  className?: string;
+  customLabel?: string;
+  variant?: ButtonVariant;
+  walletType?: WalletType;
+  walletConnectConfig?: WalletConnectConfig;
+}
+
+export interface WalletConnectConfig {
+  rpc: Record<number, string>;
+  bridge?: string;
+}
+
+export interface CoinbaseWalletProvider {
+  request: (args: { method: string }) => Promise<string[]>;
+}
+
+export interface SolanaProvider {
+  connect(): Promise<{ publicKey: { toString(): string } }>;
+}
+
+export interface WalletIconConfig {
+  metamask: string;
+  walletconnect: string;
+  coinbase: string;
+  phantom: string;
+}

--- a/registry/w3-kit/connect-wallet/utils.ts
+++ b/registry/w3-kit/connect-wallet/utils.ts
@@ -1,0 +1,66 @@
+import { ButtonVariant, WalletType, WalletConnectConfig } from './types';
+
+// Variant styles for button appearance
+export const variantStyles: Record<ButtonVariant, string> = {
+  ghost: `
+    bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800
+    text-gray-900 dark:text-gray-100
+    border-2 border-gray-200 dark:border-gray-700
+    hover:border-gray-300 dark:hover:border-gray-600
+    shadow-sm hover:shadow
+    transition-all duration-200
+  `,
+  light: `
+    bg-white dark:bg-gray-800
+    hover:bg-gray-50 dark:hover:bg-gray-700
+    text-gray-900 dark:text-gray-100
+    border border-gray-200 dark:border-gray-700
+    hover:border-gray-300 dark:hover:border-gray-600
+    shadow-sm hover:shadow
+    transition-all duration-200
+  `,
+  dark: `
+    bg-gray-900 dark:bg-gray-100
+    hover:bg-gray-800 dark:hover:bg-white
+    text-white dark:text-gray-900
+    border border-transparent
+    shadow-md hover:shadow-lg
+    transition-all duration-200
+  `,
+};
+
+// Default WalletConnect configuration
+export const DEFAULT_WALLETCONNECT_CONFIG: WalletConnectConfig = {
+  rpc: {
+    1: 'https://mainnet.infura.io/v3/YOUR_INFURA_ID',
+    4: 'https://rinkeby.infura.io/v3/YOUR_INFURA_ID',
+  },
+  bridge: 'https://bridge.walletconnect.org',
+};
+
+// Wallet icon URLs
+export const WALLET_ICONS = {
+  metamask: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/MetaMask_Fox.svg/2048px-MetaMask_Fox.svg.png',
+  walletconnect: 'https://cdn-images-1.medium.com/max/1200/1*fgRGbOjhoJMHqh9czHETZQ.png',
+  coinbase: 'https://cdn.iconscout.com/icon/free/png-256/free-coinbase-logo-icon-download-in-svg-png-gif-file-formats--web-crypro-trading-platform-logos-pack-icons-7651204.png',
+};
+
+// Get default label for wallet type
+export const getDefaultLabel = (type: WalletType): string => {
+  switch (type) {
+    case 'metamask':
+      return 'Connect MetaMask';
+    case 'walletconnect':
+      return 'WalletConnect';
+    case 'coinbase':
+      return 'Coinbase Wallet';
+    case 'phantom':
+      return 'Phantom Wallet';
+    default:
+      return 'Connect Wallet';
+  }
+};
+
+// Animation classes
+export const buttonAnimation = "transform hover:scale-[1.02] active:scale-[0.98]";
+export const spinnerAnimation = "animate-spin h-5 w-5";


### PR DESCRIPTION
## Summary
- Migrate ConnectWalletButton component to shadcn registry format
- Extract types and utilities to separate files for better maintainability
- Replace `next/image` with native `img` for framework-agnostic portability
- Support multiple wallet types: MetaMask, WalletConnect, Coinbase Wallet, Phantom (Solana)

## Changes
| File | Description |
|------|-------------|
| `registry/w3-kit/connect-wallet/connect-wallet.tsx` | Main component with wallet connection logic |
| `registry/w3-kit/connect-wallet/types.ts` | TypeScript interfaces (WalletType, ButtonVariant, ConnectWalletButtonProps) |
| `registry/w3-kit/connect-wallet/utils.ts` | Variant styles, wallet icons, and helper functions |
| `registry.json` | shadcn registry manifest |
| `components.json` | shadcn configuration |

## Installation
```bash
npx shadcn@latest add @w3-kit/connect-wallet
```

## Supported Wallets
- MetaMask (EVM)
- WalletConnect (EVM)
- Coinbase Wallet (EVM)
- Phantom (Solana)

## Test plan
- [ ] Verify component renders correctly with each wallet type
- [ ] Test MetaMask connection flow
- [ ] Test WalletConnect QR code flow
- [ ] Test Coinbase Wallet connection
- [ ] Test Phantom wallet connection (Solana)
- [ ] Verify variant styles (ghost, light, dark)
- [ ] Test error handling when wallet not installed

Closes #4