### PR TITLE
[Migration] Migrate NetworkSwitcher to shadcn registry (#13)

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/registry.json
+++ b/registry.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry.json",
+  "name": "w3-kit",
+  "homepage": "https://w3-kit.com",
+  "items": [
+    {
+      "name": "network-switcher",
+      "type": "registry:component",
+      "title": "Network Switcher",
+      "description": "Blockchain network selector with search, mainnet/testnet toggle, and network details display.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/w3-kit/network-switcher/network-switcher.tsx",
+          "type": "registry:component",
+          "target": "components/w3-kit/network-switcher.tsx"
+        },
+        {
+          "path": "registry/w3-kit/network-switcher/types.ts",
+          "type": "registry:component",
+          "target": "components/w3-kit/network-switcher/types.ts"
+        },
+        {
+          "path": "registry/w3-kit/network-switcher/utils.ts",
+          "type": "registry:component",
+          "target": "components/w3-kit/network-switcher/utils.ts"
+        },
+        {
+          "path": "registry/w3-kit/network-switcher/networks.ts",
+          "type": "registry:component",
+          "target": "components/w3-kit/network-switcher/networks.ts"
+        }
+      ]
+    }
+  ]
+}

--- a/registry/w3-kit/network-switcher/network-switcher.tsx
+++ b/registry/w3-kit/network-switcher/network-switcher.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import React, { useState } from "react";
+import { NetworkSwitcherProps } from "./types";
+
+export function NetworkSwitcher({
+  networks,
+  testNetworks,
+  onSwitch,
+  className = "",
+}: NetworkSwitcherProps) {
+  const [showTestnets, setShowTestnets] = useState(false);
+  const [selectedChainId, setSelectedChainId] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const networkStatus: "connected" | "connecting" | "error" = "connected";
+  const gasPrice = "";
+  const latency = 0;
+
+  const currentNetworks = showTestnets ? testNetworks : networks;
+
+  const filteredNetworks = currentNetworks.filter(
+    (network) =>
+      network.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      network.chainId.toString().includes(searchQuery)
+  );
+
+  const handleNetworkSwitch = async (chainId: number) => {
+    try {
+      setIsLoading(true);
+      setSelectedChainId(chainId);
+      await onSwitch(chainId);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const selectedNetwork = [...networks, ...testNetworks].find(
+    (n) => n.chainId === selectedChainId
+  );
+
+  function StatusIndicator() {
+    return (
+      <div className="flex items-center gap-2">
+        <div
+          className={`w-2 h-2 rounded-full ${
+            networkStatus === "connected"
+              ? "bg-green-500"
+              : networkStatus === "connecting"
+              ? "bg-yellow-500"
+              : "bg-red-500"
+          }`}
+        />
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          {networkStatus === "connected"
+            ? "Connected"
+            : networkStatus === "connecting"
+            ? "Connecting..."
+            : "Error"}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`bg-white dark:bg-gray-800 rounded-lg border border-gray-200
+      dark:border-gray-700 shadow-sm w-full max-w-3xl mx-auto transition-all
+      duration-300 ease-in-out transform hover:shadow-lg ${className}`}
+    >
+      {/* Header Section */}
+      <div className="p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white">
+              Network
+            </h2>
+            <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 mt-1">
+              Select a blockchain network to connect to
+            </p>
+          </div>
+          <div className="flex items-center gap-2 w-full sm:w-auto">
+            <div className="relative flex-1 sm:flex-initial">
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search networks..."
+                className="w-full px-3 py-1.5 text-sm border border-gray-200 dark:border-gray-700
+                  rounded-lg bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-white
+                  focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+              />
+              {searchQuery && (
+                <button
+                  onClick={() => setSearchQuery("")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400
+                    hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+            <button
+              onClick={() => setShowTestnets(!showTestnets)}
+              className="text-xs sm:text-sm px-3 py-1.5 border border-gray-200 dark:border-gray-700
+                rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700
+                transition-all duration-200 whitespace-nowrap flex items-center gap-2
+                transform active:scale-95"
+            >
+              {showTestnets ? "Show Mainnets" : "Show Testnets"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Network Status */}
+      <div
+        className="px-4 sm:px-6 py-3 bg-gray-50 dark:bg-gray-800/50
+        border-b border-gray-200 dark:border-gray-700"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <StatusIndicator />
+          {gasPrice && (
+            <div className="flex items-center gap-2">
+              <svg
+                className="w-4 h-4 text-gray-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 10V3L4 14h7v7l9-11h-7z"
+                />
+              </svg>
+              <span className="text-sm text-gray-600 dark:text-gray-400">
+                Gas: {gasPrice} Gwei
+              </span>
+            </div>
+          )}
+          {latency > 0 && (
+            <div className="flex items-center gap-2">
+              <svg
+                className="w-4 h-4 text-gray-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <span className="text-sm text-gray-600 dark:text-gray-400">
+                Latency: {latency}ms
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Networks Grid */}
+      <div className="p-4 sm:p-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {filteredNetworks.map((network) => (
+            <button
+              key={network.chainId}
+              onClick={() => handleNetworkSwitch(network.chainId)}
+              disabled={isLoading}
+              className={`relative p-4 text-left border rounded-lg transition-all duration-200
+                hover:border-blue-500 hover:shadow-sm
+                ${
+                  selectedChainId === network.chainId
+                    ? "border-blue-500 bg-blue-50 dark:bg-blue-900/20"
+                    : "border-gray-200 dark:border-gray-700"
+                } ${isLoading ? "opacity-50 cursor-not-allowed" : ""}`}
+            >
+              <div className="flex items-center space-x-3">
+                {network.logoURI && (
+                  <div className="relative w-8 h-8">
+                    <img
+                      src={network.logoURI}
+                      alt={network.name}
+                      width={32}
+                      height={32}
+                      className="rounded-full object-contain"
+                    />
+                  </div>
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium text-gray-900 dark:text-white truncate">
+                    {network.name}
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                    Chain ID: {network.chainId}
+                  </div>
+                </div>
+                {selectedChainId === network.chainId && (
+                  <div className="flex-shrink-0">
+                    <div className="w-2 h-2 bg-blue-500 rounded-full" />
+                  </div>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {filteredNetworks.length === 0 && (
+          <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+            No networks found matching your search
+          </div>
+        )}
+
+        {/* Network Details */}
+        {selectedNetwork && (
+          <div
+            className="mt-6 border border-gray-200 dark:border-gray-700 rounded-lg
+            divide-y divide-gray-200 dark:divide-gray-700 text-sm"
+          >
+            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
+              <span className="text-gray-600 dark:text-gray-400">RPC URL</span>
+              <code
+                className="text-xs sm:text-sm text-gray-900 dark:text-white font-mono bg-gray-50
+                dark:bg-gray-700 px-2 py-1 rounded break-all"
+              >
+                {selectedNetwork.rpcUrl}
+              </code>
+            </div>
+            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
+              <span className="text-gray-600 dark:text-gray-400">Currency</span>
+              <span className="font-medium text-gray-900 dark:text-white">
+                {selectedNetwork.currency}
+              </span>
+            </div>
+            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
+              <span className="text-gray-600 dark:text-gray-400">Explorer</span>
+              <a
+                href={selectedNetwork.blockExplorer}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline flex items-center gap-1"
+              >
+                View Explorer
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                  />
+                </svg>
+              </a>
+            </div>
+            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
+              <span className="text-gray-600 dark:text-gray-400">
+                Connection
+              </span>
+              <div className="flex items-center gap-4">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 rounded-full bg-green-500" />
+                  <span className="text-sm text-gray-900 dark:text-white">
+                    RPC
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 rounded-full bg-green-500" />
+                  <span className="text-sm text-gray-900 dark:text-white">
+                    WebSocket
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default NetworkSwitcher;

--- a/registry/w3-kit/network-switcher/networks.ts
+++ b/registry/w3-kit/network-switcher/networks.ts
@@ -1,0 +1,72 @@
+import { Network } from "./types";
+
+export const NETWORKS: Network[] = [
+  {
+    chainId: 1,
+    name: "Ethereum Mainnet",
+    symbol: "ETH",
+    currency: "ETH",
+    rpcUrl: "https://mainnet.infura.io/v3/your-api-key",
+    blockExplorer: "https://etherscan.io",
+    logoURI: "https://cryptologos.cc/logos/ethereum-eth-logo.svg?v=040",
+  },
+  {
+    chainId: 137,
+    name: "Polygon",
+    symbol: "MATIC",
+    currency: "MATIC",
+    rpcUrl: "https://polygon-rpc.com",
+    blockExplorer: "https://polygonscan.com",
+    logoURI: "https://cryptologos.cc/logos/polygon-matic-logo.svg?v=040",
+  },
+  {
+    chainId: 56,
+    name: "BNB Smart Chain",
+    symbol: "BNB",
+    currency: "BNB",
+    rpcUrl: "https://bsc-dataseed.binance.org",
+    blockExplorer: "https://bscscan.com",
+    logoURI: "https://cryptologos.cc/logos/bnb-bnb-logo.svg?v=040",
+  },
+  {
+    chainId: 43114,
+    name: "Avalanche",
+    symbol: "AVAX",
+    currency: "AVAX",
+    rpcUrl: "https://api.avax.network/ext/bc/C/rpc",
+    blockExplorer: "https://snowtrace.io",
+    logoURI: "https://cryptologos.cc/logos/avalanche-avax-logo.svg?v=040",
+  },
+];
+
+export const TEST_NETWORKS: Network[] = [
+  {
+    chainId: 5,
+    name: "Goerli",
+    symbol: "ETH",
+    currency: "ETH",
+    rpcUrl: "https://eth-goerli.g.alchemy.com/v2/your-api-key",
+    blockExplorer: "https://goerli.etherscan.io",
+    logoURI:
+      "https://ethereum.org/static/6b935ac0e6194247347855dc3d328e83/6ed5f/eth-diamond-black.webp",
+  },
+  {
+    chainId: 80001,
+    name: "Mumbai",
+    symbol: "MATIC",
+    currency: "MATIC",
+    rpcUrl: "https://polygon-mumbai.g.alchemy.com/v2/your-api-key",
+    blockExplorer: "https://mumbai.polygonscan.com",
+    logoURI: "https://cryptologos.cc/logos/polygon-matic-logo.svg",
+  },
+  {
+    chainId: 421613,
+    name: "Arbitrum Goerli",
+    symbol: "ETH",
+    currency: "ETH",
+    rpcUrl: "https://arb-goerli.g.alchemy.com/v2/your-api-key",
+    blockExplorer: "https://goerli.arbiscan.io",
+    logoURI:
+      "https://assets.coingecko.com/coins/images/16547/small/photo_2023-03-29_21.47.00.jpeg",
+  },
+];

--- a/registry/w3-kit/network-switcher/types.ts
+++ b/registry/w3-kit/network-switcher/types.ts
@@ -1,0 +1,16 @@
+export interface Network {
+  chainId: number;
+  name: string;
+  symbol: string;
+  currency: string;
+  rpcUrl: string;
+  blockExplorer: string;
+  logoURI: string;
+}
+
+export interface NetworkSwitcherProps {
+  networks: Network[];
+  testNetworks: Network[];
+  onSwitch: (chainId: number) => void;
+  className?: string;
+}

--- a/registry/w3-kit/network-switcher/utils.ts
+++ b/registry/w3-kit/network-switcher/utils.ts
@@ -1,0 +1,51 @@
+import { Network } from "./types";
+
+export async function switchNetwork(network: Network): Promise<void> {
+  if (typeof window === "undefined" || !window.ethereum) {
+    throw new Error("No crypto wallet found");
+  }
+
+  try {
+    await window.ethereum.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: `0x${network.chainId.toString(16)}` }],
+    });
+  } catch (switchError: unknown) {
+    if (
+      typeof switchError === "object" &&
+      switchError &&
+      "code" in switchError &&
+      switchError.code === 4902
+    ) {
+      try {
+        await window.ethereum.request({
+          method: "wallet_addEthereumChain",
+          params: [
+            {
+              chainId: `0x${network.chainId.toString(16)}`,
+              chainName: network.name,
+              nativeCurrency: {
+                name: network.symbol,
+                symbol: network.symbol,
+                decimals: 18,
+              },
+              rpcUrls: [network.rpcUrl],
+              blockExplorerUrls: [network.blockExplorer],
+            },
+          ],
+        });
+      } catch {
+        throw new Error("Failed to add network");
+      }
+    }
+    throw new Error("Failed to switch network");
+  }
+}
+
+declare global {
+  interface Window {
+    ethereum?: {
+      request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Migrates NetworkSwitcher component to shadcn registry format
- Component can now be installed via `npx shadcn@latest add @w3-kit/network-switcher`
- Extracts types and utilities into separate files for better modularity
- Replaces `next/image` with native `img` for framework independence

## Changes
- `registry/w3-kit/network-switcher/network-switcher.tsx` - Main component with network grid and details
- `registry/w3-kit/network-switcher/types.ts` - TypeScript interfaces (Network, NetworkSwitcherProps)
- `registry/w3-kit/network-switcher/utils.ts` - Wallet integration (switchNetwork function)
- `registry/w3-kit/network-switcher/networks.ts` - Default network configurations
- `registry.json` - Registry configuration
- `components.json` - shadcn configuration

## Features
- Network search functionality
- Mainnet/Testnet toggle
- Network details display (RPC URL, currency, explorer)
- Connection status indicator
- Grid layout with selection state
- Dark mode support

Resolves #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)