### PR TITLE
feat: redesign ConnectWallet as pure UI wallet picker

### DIFF
--- a/components/connect-wallet/ConnectWallet.tsx
+++ b/components/connect-wallet/ConnectWallet.tsx
@@ -1,67 +1,15 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
-import { Wallet, Loader2 } from "lucide-react";
-import { cn } from "../../lib/utils";
-import { Button } from "../ui/button";
-import "../../lib/ethereum";
-
-export interface ConnectWalletButtonProps {
-  onConnect?: (address: string) => void;
-  onError?: (error: Error) => void;
-  className?: string;
-}
-
-export function ConnectWalletButton({ onConnect, onError, className }: ConnectWalletButtonProps) {
-  const [isConnecting, setIsConnecting] = useState(false);
-  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
-
-  const formatAddress = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-
-  const handleConnect = useCallback(async () => {
-    if (isConnecting) return;
-    setIsConnecting(true);
-
-    try {
-      if (typeof window === "undefined" || !window.ethereum) {
-        throw new Error("No wallet detected. Please install MetaMask.");
-      }
-
-      const accounts = (await window.ethereum.request({
-        method: "eth_requestAccounts",
-      })) as string[];
-
-      if (accounts && accounts.length > 0) {
-        setConnectedAddress(accounts[0]);
-        onConnect?.(accounts[0]);
-      }
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error("Failed to connect wallet");
-      onError?.(error);
-    } finally {
-      setIsConnecting(false);
-    }
-  }, [isConnecting, onConnect, onError]);
-
-  const handleDisconnect = useCallback(() => {
-    setConnectedAddress(null);
-  }, []);
-
-  if (connectedAddress) {
-    return (
-      <Button variant="outline" onClick={handleDisconnect} className={cn("gap-2", className)}>
-        <Wallet className="h-4 w-4" />
-        <span className="font-mono text-xs">{formatAddress(connectedAddress)}</span>
-      </Button>
-    );
-  }
-
-  return (
-    <Button onClick={handleConnect} disabled={isConnecting} className={cn("gap-2", className)}>
-      {isConnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wallet className="h-4 w-4" />}
-      {isConnecting ? "Connecting..." : "Connect Wallet"}
-    </Button>
-  );
-}
-
-export default ConnectWalletButton;
+/**
+ * ConnectWallet — Pure UI wallet picker component.
+ *
+ * This is the simplified components/ version that re-exports the registry
+ * implementation. For the full source, see registry/w3-kit/connect-wallet/.
+ */
+export { ConnectWallet, default } from "../../registry/w3-kit/connect-wallet/connect-wallet";
+export type {
+  ConnectWalletProps,
+  WalletOption,
+  ConnectedAccount,
+  Chain,
+} from "../../registry/w3-kit/connect-wallet/types";

--- a/registry/w3-kit/connect-wallet/connect-wallet.tsx
+++ b/registry/w3-kit/connect-wallet/connect-wallet.tsx
@@ -1,184 +1,380 @@
 "use client";
 
-import React, { useState, useCallback } from "react";
-import { ConnectWalletButtonProps } from "./types";
-import {
-  variantStyles,
-  WALLET_ICONS,
-  getDefaultLabel,
-  buttonAnimation,
-  spinnerAnimation,
-} from "./utils";
-import "../../../lib/ethereum";
+import React, { useState } from "react";
+import { Wallet, Check, Loader2, Copy, LogOut, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ConnectWalletProps, WalletOption } from "./types";
+import { truncateAddress, findWallet } from "./utils";
 
-// Phantom wallet icon as inline SVG
-const PhantomIcon = () => (
-  <svg width="24" height="24" viewBox="0 0 128 128" fill="none">
-    <rect width="128" height="128" rx="64" fill="#AB9FF2" />
-    <path
-      d="M110.984 64.206C110.984 89.2476 90.7077 109.524 65.666 109.524C40.6244 109.524 20.3477 89.2476 20.3477 64.206C20.3477 39.1644 40.6244 18.8877 65.666 18.8877C90.7077 18.8877 110.984 39.1644 110.984 64.206Z"
-      fill="white"
-    />
-  </svg>
-);
+function WalletIcon({ wallet, size = 24 }: { wallet: WalletOption; size?: number }) {
+  if (typeof wallet.icon === "string") {
+    return (
+      <img
+        src={wallet.icon}
+        alt={wallet.name}
+        width={size}
+        height={size}
+        className="shrink-0 rounded-lg"
+      />
+    );
+  }
+  return <span className="shrink-0">{wallet.icon}</span>;
+}
 
-// Loading spinner component
-const LoadingSpinner = () => (
-  <svg className={spinnerAnimation} viewBox="0 0 24 24">
-    <circle
-      className="opacity-25"
-      cx="12"
-      cy="12"
-      r="10"
-      stroke="currentColor"
-      strokeWidth="4"
-      fill="none"
-    />
-    <path
-      className="opacity-75"
-      fill="currentColor"
-      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-    />
-  </svg>
-);
-
-export const ConnectWalletButton: React.FC<ConnectWalletButtonProps> = ({
+export function ConnectWallet({
+  wallets,
+  connectedAccount,
   onConnect,
-  onError,
-  className = "",
-  customLabel,
-  variant = "dark",
-  walletType = "metamask",
-}) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  onDisconnect,
+  chains,
+  activeChain,
+  onChainSwitch,
+  recentWalletId,
+  variant = "default",
+  loading = false,
+  className,
+}: ConnectWalletProps) {
+  const [chainsOpen, setChainsOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
 
-  const connectEIP1193 = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
+  const isConnected = !!connectedAccount;
+  const connectedWallet = isConnected
+    ? findWallet(wallets, connectedAccount.walletId)
+    : undefined;
+  const recentWallet = findWallet(wallets, recentWalletId);
 
-    try {
-      if (typeof window.ethereum === "undefined") {
-        throw new Error("No wallet found. Please install a browser wallet.");
-      }
-
-      const accounts = await window.ethereum.request({
-        method: "eth_requestAccounts",
-      });
-
-      if (accounts && Array.isArray(accounts) && accounts.length > 0) {
-        onConnect?.(accounts[0] as string);
-      } else {
-        throw new Error("No accounts found");
-      }
-    } catch (err) {
-      const error = err as Error;
-      setError(error.message);
-      onError?.(error);
-    } finally {
-      setIsLoading(false);
+  const handleCopy = () => {
+    if (connectedAccount?.address) {
+      navigator.clipboard.writeText(connectedAccount.address).catch(() => {});
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
     }
-  }, [onConnect, onError]);
-
-  const connectCoinbase = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      if (!window.coinbaseWalletExtension) {
-        throw new Error("Coinbase Wallet is not installed");
-      }
-
-      const accounts = await window.coinbaseWalletExtension.request({
-        method: "eth_requestAccounts",
-      });
-
-      if (accounts && Array.isArray(accounts) && accounts.length > 0) {
-        onConnect?.(accounts[0]);
-      } else {
-        throw new Error("No accounts found");
-      }
-    } catch (err) {
-      const error = err as Error;
-      setError(error.message);
-      onError?.(error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [onConnect, onError]);
-
-  const connectPhantom = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      if (!window.phantom?.solana) {
-        throw new Error("Phantom wallet is not installed");
-      }
-
-      const response = await window.phantom.solana.connect();
-      const address = response.publicKey.toString();
-      onConnect?.(address);
-    } catch (err) {
-      const error = err as Error;
-      setError(error.message);
-      onError?.(error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [onConnect, onError]);
-
-  const handleConnect = useCallback(() => {
-    switch (walletType) {
-      case "metamask":
-        return connectEIP1193();
-      case "walletconnect":
-        return connectEIP1193();
-      case "coinbase":
-        return connectCoinbase();
-      case "phantom":
-        return connectPhantom();
-      default:
-        return connectEIP1193();
-    }
-  }, [walletType, connectEIP1193, connectCoinbase, connectPhantom]);
-
-  const renderWalletIcon = () => {
-    if (walletType === "phantom") {
-      return <PhantomIcon />;
-    }
-
-    const iconUrl = WALLET_ICONS[walletType];
-    return <img src={iconUrl} alt={walletType} width={24} height={24} className="rounded-sm" />;
   };
 
-  return (
-    <div className="flex flex-col items-center">
-      <button
-        onClick={handleConnect}
-        disabled={isLoading}
-        className={`
-          px-6 py-3 rounded-xl font-medium
-          flex items-center justify-center min-w-[240px]
-          disabled:opacity-50 disabled:cursor-not-allowed
-          ${buttonAnimation}
-          ${variantStyles[variant]}
-          ${className}
-        `}
-      >
-        {isLoading ? (
-          <div className="flex items-center space-x-2">
-            <LoadingSpinner />
-            <span>Connecting...</span>
-          </div>
-        ) : (
-          <div className="flex items-center space-x-3">
-            <div className="w-6 h-6 flex items-center justify-center">{renderWalletIcon()}</div>
-            <span className="text-[15px]">{customLabel || getDefaultLabel(walletType)}</span>
-          </div>
-        )}
-      </button>
-      {error && <p className="mt-2 text-sm text-red-500 dark:text-red-400">{error}</p>}
+  const handleWalletClick = (walletId: string) => {
+    onConnect(walletId);
+    setPickerOpen(false);
+  };
+
+  /* ── Shared wallet list ──────────────────────────────────────────── */
+  const renderWalletList = (opts?: { compact?: boolean }) => (
+    <div className={cn("flex flex-col", opts?.compact ? "gap-0.5 p-2" : "gap-1 px-5 pb-5")}>
+      {recentWallet && !isConnected && (
+        <>
+          <p className="mb-1 mt-1 text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            Recent
+          </p>
+          <button
+            onClick={() => handleWalletClick(recentWallet.id)}
+            disabled={loading}
+            className={cn(
+              "flex w-full items-center gap-3 rounded-xl border-2 border-gray-900/10 bg-gray-50 p-3 text-left transition-all",
+              "hover:border-gray-900/20 dark:border-white/10 dark:bg-gray-800/50 dark:hover:border-white/20",
+              loading && "pointer-events-none opacity-50",
+            )}
+          >
+            <WalletIcon wallet={recentWallet} size={opts?.compact ? 24 : 28} />
+            <span className="flex-1 text-sm font-medium text-gray-900 dark:text-gray-100">
+              {recentWallet.name}
+            </span>
+            <span className="text-sm text-gray-400">→</span>
+          </button>
+          <p className="mb-1 mt-3 text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            All Wallets
+          </p>
+        </>
+      )}
+
+      {wallets.map((w) => {
+        const isActive = loading && connectedAccount === null;
+        return (
+          <button
+            key={w.id}
+            onClick={() => handleWalletClick(w.id)}
+            disabled={loading}
+            className={cn(
+              "flex w-full items-center gap-3 rounded-xl p-3 text-left transition-all",
+              "hover:bg-gray-100 dark:hover:bg-gray-800",
+              loading && "pointer-events-none opacity-40",
+            )}
+          >
+            <WalletIcon wallet={w} size={opts?.compact ? 24 : 28} />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {w.name}
+                </span>
+                {w.installed === false && (
+                  <span className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                    Not installed
+                  </span>
+                )}
+              </div>
+              {w.ecosystem && !opts?.compact && (
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  {w.ecosystem === "evm" ? "Ethereum" : w.ecosystem === "solana" ? "Solana" : "Multi-chain"}
+                </span>
+              )}
+            </div>
+            <span className="text-sm text-gray-400 dark:text-gray-500">→</span>
+          </button>
+        );
+      })}
     </div>
   );
-};
+
+  /* ── COMPACT VARIANT ─────────────────────────────────────────────── */
+  if (variant === "compact") {
+    if (isConnected && connectedWallet) {
+      return (
+        <div className={cn("relative", className)}>
+          <button
+            onClick={() => setPickerOpen(!pickerOpen)}
+            className={cn(
+              "inline-flex items-center gap-2.5 rounded-xl border border-gray-200 bg-white px-4 py-2.5 transition-all",
+              "hover:border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-gray-600",
+            )}
+          >
+            <div className="h-2 w-2 rounded-full bg-green-500" />
+            <WalletIcon wallet={connectedWallet} size={18} />
+            <span className="font-mono text-xs font-medium text-gray-900 dark:text-gray-100">
+              {truncateAddress(connectedAccount.address)}
+            </span>
+            {activeChain && (
+              <span
+                className="rounded-md px-2 py-0.5 text-[10px] font-medium"
+                style={{
+                  background: (activeChain.color ?? "#888") + "14",
+                  color: activeChain.color ?? "#888",
+                }}
+              >
+                {activeChain.name}
+              </span>
+            )}
+            <ChevronDown
+              size={14}
+              className={cn(
+                "text-gray-400 transition-transform",
+                pickerOpen && "rotate-180",
+              )}
+            />
+          </button>
+
+          {pickerOpen && (
+            <div className="mt-2 w-64 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
+              <button
+                onClick={() => { onDisconnect?.(); setPickerOpen(false); }}
+                className="flex w-full items-center gap-2.5 px-4 py-3 text-left text-sm font-medium text-gray-600 transition-colors hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800"
+              >
+                <LogOut size={16} />
+                Disconnect
+              </button>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div className={cn("relative", className)}>
+        <button
+          onClick={() => setPickerOpen(!pickerOpen)}
+          disabled={loading}
+          className={cn(
+            "inline-flex items-center gap-2 rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition-all",
+            "hover:bg-gray-800 active:scale-[0.98] dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100",
+            loading && "pointer-events-none opacity-70",
+          )}
+        >
+          {loading ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            <Wallet size={16} />
+          )}
+          {loading ? "Connecting..." : "Connect Wallet"}
+          <ChevronDown
+            size={14}
+            className={cn("transition-transform", pickerOpen && "rotate-180")}
+          />
+        </button>
+
+        {pickerOpen && (
+          <div className="mt-2 w-72 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
+            {renderWalletList({ compact: true })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  /* ── DEFAULT VARIANT — full card picker ──────────────────────────── */
+  if (isConnected && connectedWallet) {
+    return (
+      <div
+        className={cn(
+          "w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+          className,
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 rounded-full bg-green-500" />
+            <span className="text-base font-semibold text-gray-900 dark:text-gray-100">
+              Connected
+            </span>
+          </div>
+          {activeChain && (
+            <span
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium"
+              style={{
+                background: (activeChain.color ?? "#888") + "14",
+                color: activeChain.color ?? "#888",
+              }}
+            >
+              <span
+                className="h-2 w-2 rounded-full"
+                style={{ background: activeChain.color ?? "#888" }}
+              />
+              {activeChain.name}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4 p-5">
+          {/* Account */}
+          <div className="flex items-center gap-3.5">
+            <WalletIcon wallet={connectedWallet} size={40} />
+            <div className="flex-1 min-w-0">
+              <p className="text-[15px] font-semibold text-gray-900 dark:text-gray-100">
+                {connectedWallet.name}
+              </p>
+              <p className="font-mono text-sm text-gray-500 dark:text-gray-400">
+                {truncateAddress(connectedAccount.address)}
+              </p>
+            </div>
+            <button
+              onClick={handleCopy}
+              className={cn(
+                "flex rounded-lg border border-gray-200 p-2 transition-colors",
+                "hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800",
+              )}
+              aria-label="Copy address"
+            >
+              {copied ? (
+                <Check size={16} className="text-green-500" />
+              ) : (
+                <Copy size={16} className="text-gray-400" />
+              )}
+            </button>
+          </div>
+
+          <div className="border-t border-gray-100 dark:border-gray-800" />
+
+          {/* Chain switcher */}
+          {chains && chains.length > 0 && onChainSwitch && (
+            <div>
+              <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                Network
+              </p>
+              <button
+                onClick={() => setChainsOpen(!chainsOpen)}
+                className={cn(
+                  "flex w-full items-center justify-between rounded-xl border border-gray-200 px-3.5 py-2.5 transition-colors",
+                  "hover:border-gray-300 dark:border-gray-700 dark:hover:border-gray-600",
+                )}
+              >
+                <span className="flex items-center gap-2 text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {activeChain && (
+                    <span
+                      className="h-2.5 w-2.5 rounded-full"
+                      style={{ background: activeChain.color ?? "#888" }}
+                    />
+                  )}
+                  {activeChain?.name ?? "Select chain"}
+                </span>
+                <ChevronDown
+                  size={16}
+                  className={cn(
+                    "text-gray-400 transition-transform",
+                    chainsOpen && "rotate-180",
+                  )}
+                />
+              </button>
+              {chainsOpen && (
+                <div className="mt-1.5 flex flex-col gap-0.5">
+                  {chains.map((c) => (
+                    <button
+                      key={c.chainId}
+                      onClick={() => {
+                        onChainSwitch(c.chainId);
+                        setChainsOpen(false);
+                      }}
+                      className={cn(
+                        "flex w-full items-center gap-2.5 rounded-xl px-3.5 py-2.5 text-left text-sm font-medium transition-colors",
+                        activeChain?.chainId === c.chainId
+                          ? "bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-gray-100"
+                          : "text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/50",
+                      )}
+                    >
+                      <span
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ background: c.color ?? "#888" }}
+                      />
+                      {c.name}
+                      {activeChain?.chainId === c.chainId && (
+                        <Check size={14} className="ml-auto text-gray-900 dark:text-gray-100" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Disconnect */}
+          {onDisconnect && (
+            <button
+              onClick={onDisconnect}
+              className={cn(
+                "flex w-full items-center justify-center gap-2 rounded-xl border border-gray-200 py-2.5 text-sm font-medium text-gray-600 transition-colors",
+                "hover:bg-gray-50 hover:text-gray-900 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100",
+              )}
+            >
+              <LogOut size={16} />
+              Disconnect
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  /* ── IDLE — wallet picker ────────────────────────────────────────── */
+  return (
+    <div
+      className={cn(
+        "w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2.5 border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <Wallet size={18} className="text-gray-900 dark:text-gray-100" />
+        <span className="text-base font-semibold text-gray-900 dark:text-gray-100">
+          Connect Wallet
+        </span>
+      </div>
+
+      {renderWalletList()}
+
+      <div className="border-t border-gray-100 px-5 py-3 text-center dark:border-gray-800">
+        <span className="text-xs text-gray-400 dark:text-gray-500">
+          {wallets.length} wallet{wallets.length !== 1 ? "s" : ""} supported
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default ConnectWallet;

--- a/registry/w3-kit/connect-wallet/types.ts
+++ b/registry/w3-kit/connect-wallet/types.ts
@@ -1,26 +1,57 @@
-export type ButtonVariant = "ghost" | "light" | "dark";
-export type WalletType = "metamask" | "walletconnect" | "coinbase" | "phantom";
+export interface WalletOption {
+  /** Unique wallet identifier */
+  id: string;
+  /** Display name */
+  name: string;
+  /** Icon URL or React node */
+  icon: string | React.ReactNode;
+  /** Ecosystem: "evm" | "solana" | "both" */
+  ecosystem?: "evm" | "solana" | "both";
+  /** Whether this wallet is installed/detected */
+  installed?: boolean;
+  /** Install URL (shown when not installed) */
+  installUrl?: string;
+}
 
-export interface ConnectWalletButtonProps {
-  onConnect?: (address: string) => void;
-  onError?: (error: Error) => void;
+export interface ConnectedAccount {
+  /** Wallet address */
+  address: string;
+  /** ID of the wallet used to connect */
+  walletId: string;
+}
+
+export interface Chain {
+  /** Chain ID (e.g. 1 for Ethereum) */
+  chainId: number;
+  /** Display name */
+  name: string;
+  /** Brand color hex */
+  color?: string;
+  /** Chain icon URL */
+  icon?: string;
+}
+
+export interface ConnectWalletProps {
+  /** List of wallets to display */
+  wallets: WalletOption[];
+  /** Connected account data. null = show wallet picker */
+  connectedAccount?: ConnectedAccount | null;
+  /** Called when user selects a wallet to connect */
+  onConnect: (walletId: string) => void;
+  /** Called when user clicks disconnect */
+  onDisconnect?: () => void;
+  /** Supported chains for the chain switcher */
+  chains?: Chain[];
+  /** Currently active chain */
+  activeChain?: Chain;
+  /** Called when user switches chain */
+  onChainSwitch?: (chainId: number) => void;
+  /** ID of the most recently used wallet (shown highlighted) */
+  recentWalletId?: string;
+  /** "default" = full picker card, "compact" = button that opens dropdown */
+  variant?: "default" | "compact";
+  /** Show loading spinner on the connecting wallet */
+  loading?: boolean;
+  /** Additional CSS classes on the root element */
   className?: string;
-  customLabel?: string;
-  variant?: ButtonVariant;
-  walletType?: WalletType;
-}
-
-export interface CoinbaseWalletProvider {
-  request: (args: { method: string }) => Promise<string[]>;
-}
-
-export interface SolanaProvider {
-  connect(): Promise<{ publicKey: { toString(): string } }>;
-}
-
-export interface WalletIconConfig {
-  metamask: string;
-  walletconnect: string;
-  coinbase: string;
-  phantom: string;
 }

--- a/registry/w3-kit/connect-wallet/utils.ts
+++ b/registry/w3-kit/connect-wallet/utils.ts
@@ -1,59 +1,14 @@
-import { ButtonVariant, WalletType } from "./types";
+/** Truncate an address to 0x1234...5678 format */
+export function truncateAddress(address: string): string {
+  if (!address || address.length <= 13) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
 
-// Variant styles for button appearance
-export const variantStyles: Record<ButtonVariant, string> = {
-  ghost: `
-    bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800
-    text-gray-900 dark:text-gray-100
-    border-2 border-gray-200 dark:border-gray-700
-    hover:border-gray-300 dark:hover:border-gray-600
-    shadow-sm hover:shadow
-    transition-all duration-200
-  `,
-  light: `
-    bg-white dark:bg-gray-800
-    hover:bg-gray-50 dark:hover:bg-gray-700
-    text-gray-900 dark:text-gray-100
-    border border-gray-200 dark:border-gray-700
-    hover:border-gray-300 dark:hover:border-gray-600
-    shadow-sm hover:shadow
-    transition-all duration-200
-  `,
-  dark: `
-    bg-gray-900 dark:bg-gray-100
-    hover:bg-gray-800 dark:hover:bg-white
-    text-white dark:text-gray-900
-    border border-transparent
-    shadow-md hover:shadow-lg
-    transition-all duration-200
-  `,
-};
-
-// Wallet icon URLs
-export const WALLET_ICONS = {
-  metamask:
-    "https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/MetaMask_Fox.svg/2048px-MetaMask_Fox.svg.png",
-  walletconnect: "https://cdn-images-1.medium.com/max/1200/1*fgRGbOjhoJMHqh9czHETZQ.png",
-  coinbase:
-    "https://cdn.iconscout.com/icon/free/png-256/free-coinbase-logo-icon-download-in-svg-png-gif-file-formats--web-crypro-trading-platform-logos-pack-icons-7651204.png",
-};
-
-// Get default label for wallet type
-export const getDefaultLabel = (type: WalletType): string => {
-  switch (type) {
-    case "metamask":
-      return "Connect MetaMask";
-    case "walletconnect":
-      return "WalletConnect";
-    case "coinbase":
-      return "Coinbase Wallet";
-    case "phantom":
-      return "Phantom Wallet";
-    default:
-      return "Connect Wallet";
-  }
-};
-
-// Animation classes
-export const buttonAnimation = "transform hover:scale-[1.02] active:scale-[0.98]";
-export const spinnerAnimation = "animate-spin h-5 w-5";
+/** Get a wallet option by ID from the wallets array */
+export function findWallet(
+  wallets: { id: string }[],
+  walletId: string | undefined,
+) {
+  if (!walletId) return undefined;
+  return wallets.find((w) => w.id === walletId);
+}


### PR DESCRIPTION
## Summary
- Complete rewrite from single-button (`walletType="metamask"`) to full wallet picker component
- Now fully **props-driven with zero blockchain dependencies** — users bring their own wallet logic (wagmi, ethers, Privy, Dynamic, etc.)
- Two variants: `default` (full card picker) and `compact` (button with dropdown)
- Connected state with address display, copy button, chain switcher, disconnect
- Recent wallet highlighting for returning users

## Breaking Changes
- `ConnectWalletButton` → `ConnectWallet` (new component name)
- `walletType` prop removed → replaced by `wallets: WalletOption[]` array
- `variant: "ghost" | "light" | "dark"` → `variant: "default" | "compact"`
- `window.ethereum` calls removed from component (moved to recipes)

## New Props API
| Prop | Type | Description |
|------|------|-------------|
| `wallets` | `WalletOption[]` | List of wallets to display |
| `connectedAccount` | `ConnectedAccount \| null` | null = show picker |
| `onConnect` | `(walletId: string) => void` | User selects wallet |
| `onDisconnect` | `() => void` | User clicks disconnect |
| `chains` | `Chain[]` | Supported chains |
| `activeChain` | `Chain` | Current chain |
| `onChainSwitch` | `(chainId: number) => void` | Chain switch |
| `variant` | `"default" \| "compact"` | Full card or button |
| `recentWalletId` | `string` | Last used wallet |
| `loading` | `boolean` | Loading state |

## Test plan
- [ ] Default variant: renders wallet picker, click wallet → calls onConnect
- [ ] Compact variant: button → dropdown → select wallet
- [ ] Connected state: shows address, copy works, chain switcher works
- [ ] Disconnect: calls onDisconnect callback
- [ ] Dark mode: all states render correctly
- [ ] Loading state: spinner on selected wallet, others dimmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)