### PR TITLE
feat: redesign NetworkSwitcher as clean list-based switcher

### DIFF
--- a/registry/w3-kit/network-switcher/network-switcher.tsx
+++ b/registry/w3-kit/network-switcher/network-switcher.tsx
@@ -1,266 +1,197 @@
 "use client";
 
-import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { NetworkSwitcherProps } from "./types";
+import React, { useState, useMemo } from "react";
+import { Check, Loader2, Search, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { NetworkSwitcherProps, Network } from "./types";
 
-export function NetworkSwitcher({
-  networks,
-  testNetworks,
-  onSwitch,
-  className = "",
-}: NetworkSwitcherProps) {
-  const [showTestnets, setShowTestnets] = useState(false);
-  const [selectedChainId, setSelectedChainId] = useState<number | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const networkStatus: "connected" | "connecting" | "error" = "connected";
-  const gasPrice = "";
-  const latency = 0;
-
-  const currentNetworks = showTestnets ? testNetworks : networks;
-
-  const filteredNetworks = currentNetworks.filter(
-    (network) =>
-      network.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      network.chainId.toString().includes(searchQuery),
-  );
-
-  const handleNetworkSwitch = async (chainId: number) => {
-    try {
-      setIsLoading(true);
-      setSelectedChainId(chainId);
-      await onSwitch(chainId);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const selectedNetwork = [...networks, ...testNetworks].find((n) => n.chainId === selectedChainId);
-
-  function StatusIndicator() {
+function NetworkIcon({ network, size = 24 }: { network: Network; size?: number }) {
+  if (network.icon) {
     return (
-      <div className="flex items-center gap-2">
-        <div
-          className={`w-2 h-2 rounded-full ${
-            networkStatus === "connected"
-              ? "bg-green-500"
-              : networkStatus === "connecting"
-                ? "bg-yellow-500"
-                : "bg-red-500"
-          }`}
-        />
-        <span className="text-sm text-muted-foreground">
-          {networkStatus === "connected"
-            ? "Connected"
-            : networkStatus === "connecting"
-              ? "Connecting..."
-              : "Error"}
-        </span>
-      </div>
+      <img
+        src={network.icon}
+        alt={network.name}
+        width={size}
+        height={size}
+        className="shrink-0 rounded-full"
+      />
     );
   }
 
   return (
-    <div
-      className={`bg-card rounded-lg border shadow-sm w-full max-w-3xl mx-auto transition-all
-      duration-300 ease-in-out transform hover:shadow-lg ${className}`}
+    <span
+      className="flex shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white"
+      style={{
+        width: size,
+        height: size,
+        background: network.color ?? "#888",
+      }}
     >
-      {/* Header Section */}
-      <div className="p-4 sm:p-6 border-b">
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          <div>
-            <h2 className="text-lg sm:text-xl font-semibold text-foreground">Network</h2>
-            <p className="text-xs sm:text-sm text-muted-foreground mt-1">
-              Select a blockchain network to connect to
-            </p>
-          </div>
-          <div className="flex items-center gap-2 w-full sm:w-auto">
-            <div className="relative flex-1 sm:flex-initial">
-              <input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search networks..."
-                className="w-full px-3 py-1.5 text-sm border
-                  rounded-lg bg-background text-foreground
-                  focus:outline-none focus:ring-2 focus:ring-ring transition-all"
-              />
-              {searchQuery && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => setSearchQuery("")}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 p-0"
-                >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </Button>
-              )}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setShowTestnets(!showTestnets)}
-              className="text-xs sm:text-sm whitespace-nowrap"
-            >
-              {showTestnets ? "Show Mainnets" : "Show Testnets"}
-            </Button>
-          </div>
-        </div>
-      </div>
+      {network.symbol?.slice(0, 2) ?? network.name.slice(0, 2)}
+    </span>
+  );
+}
 
-      {/* Network Status */}
-      <div
-        className="px-4 sm:px-6 py-3 bg-muted/50
-        border-b"
-      >
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <StatusIndicator />
-          {gasPrice && (
-            <div className="flex items-center gap-2">
-              <svg
-                className="w-4 h-4 text-muted-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M13 10V3L4 14h7v7l9-11h-7z"
-                />
-              </svg>
-              <span className="text-sm text-muted-foreground">Gas: {gasPrice} Gwei</span>
-            </div>
-          )}
-          {latency > 0 && (
-            <div className="flex items-center gap-2">
-              <svg
-                className="w-4 h-4 text-muted-foreground"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              <span className="text-sm text-muted-foreground">Latency: {latency}ms</span>
+export function NetworkSwitcher({
+  networks,
+  activeChainId,
+  onSwitch,
+  searchable = false,
+  showTestnetToggle,
+  switchingTo,
+  className,
+}: NetworkSwitcherProps) {
+  const [search, setSearch] = useState("");
+  const [showTestnets, setShowTestnets] = useState(false);
+
+  const hasTestnets = useMemo(
+    () => networks.some((n) => n.testnet),
+    [networks],
+  );
+
+  const shouldShowToggle = showTestnetToggle ?? hasTestnets;
+
+  const filtered = useMemo(() => {
+    let list = networks;
+
+    if (shouldShowToggle) {
+      list = list.filter((n) => (showTestnets ? n.testnet : !n.testnet));
+    }
+
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      list = list.filter(
+        (n) =>
+          n.name.toLowerCase().includes(q) ||
+          n.chainId.toString().includes(q) ||
+          n.symbol?.toLowerCase().includes(q),
+      );
+    }
+
+    return list;
+  }, [networks, showTestnets, shouldShowToggle, search]);
+
+  const activeNetwork = networks.find((n) => n.chainId === activeChainId);
+
+  const handleSwitch = (chainId: number) => {
+    if (chainId === activeChainId) return;
+    onSwitch(chainId);
+  };
+
+  return (
+    <div
+      className={cn(
+        "w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <div className="flex items-center gap-2.5">
+          <span className="text-base font-semibold text-gray-900 dark:text-gray-100">
+            Network
+          </span>
+          {activeNetwork && (
+            <div className="flex items-center gap-1.5">
+              <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {activeNetwork.name}
+              </span>
             </div>
           )}
         </div>
-      </div>
-
-      {/* Networks Grid */}
-      <div className="p-4 sm:p-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {filteredNetworks.map((network) => (
-            <Button
-              key={network.chainId}
-              variant={selectedChainId === network.chainId ? "default" : "outline"}
-              onClick={() => handleNetworkSwitch(network.chainId)}
-              disabled={isLoading}
-              className={`relative p-4 h-auto text-left justify-start hover:shadow-sm
-                ${selectedChainId === network.chainId ? "border-primary" : ""}`}
-            >
-              <div className="flex items-center space-x-3 w-full">
-                {network.logoURI && (
-                  <div className="relative w-8 h-8">
-                    <img
-                      src={network.logoURI}
-                      alt={network.name}
-                      width={32}
-                      height={32}
-                      className="rounded-full object-contain"
-                    />
-                  </div>
-                )}
-                <div className="min-w-0 flex-1">
-                  <div className="font-medium truncate">{network.name}</div>
-                  <div className="text-xs text-muted-foreground mt-0.5">
-                    Chain ID: {network.chainId}
-                  </div>
-                </div>
-                {selectedChainId === network.chainId && (
-                  <div className="flex-shrink-0">
-                    <div className="w-2 h-2 bg-primary-foreground rounded-full" />
-                  </div>
-                )}
-              </div>
-            </Button>
-          ))}
-        </div>
-
-        {filteredNetworks.length === 0 && (
-          <div className="text-center py-8 text-muted-foreground">
-            No networks found matching your search
-          </div>
-        )}
-
-        {/* Network Details */}
-        {selectedNetwork && (
-          <div
-            className="mt-6 border rounded-lg
-            divide-y text-sm"
+        {shouldShowToggle && (
+          <button
+            onClick={() => setShowTestnets(!showTestnets)}
+            className={cn(
+              "rounded-lg px-2.5 py-1 text-xs font-medium transition-colors",
+              showTestnets
+                ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
+                : "border border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600",
+            )}
           >
-            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
-              <span className="text-muted-foreground">RPC URL</span>
-              <code
-                className="text-xs sm:text-sm text-foreground font-mono bg-muted
-                px-2 py-1 rounded break-all"
+            Testnets
+          </button>
+        )}
+      </div>
+
+      {/* Search */}
+      {searchable && (
+        <div className="border-b border-gray-100 px-5 py-3 dark:border-gray-800">
+          <div className="relative">
+            <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search networks..."
+              className={cn(
+                "w-full rounded-lg border border-gray-200 bg-transparent py-2 pl-8 pr-8 text-sm text-gray-900 placeholder:text-gray-400",
+                "focus:border-gray-300 focus:outline-none dark:border-gray-700 dark:text-gray-100 dark:focus:border-gray-600",
+              )}
+            />
+            {search && (
+              <button
+                onClick={() => setSearch("")}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
               >
-                {selectedNetwork.rpcUrl}
-              </code>
-            </div>
-            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
-              <span className="text-muted-foreground">Currency</span>
-              <span className="font-medium text-foreground">{selectedNetwork.currency}</span>
-            </div>
-            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
-              <span className="text-muted-foreground">Explorer</span>
-              <a
-                href={selectedNetwork.blockExplorer}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline flex items-center gap-1"
-              >
-                View Explorer
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                  />
-                </svg>
-              </a>
-            </div>
-            <div className="p-3 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
-              <span className="text-muted-foreground">Connection</span>
-              <div className="flex items-center gap-4">
-                <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 rounded-full bg-green-500" />
-                  <span className="text-sm text-foreground">RPC</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 rounded-full bg-green-500" />
-                  <span className="text-sm text-foreground">WebSocket</span>
-                </div>
+                <X size={14} />
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Network list */}
+      <div className="flex flex-col gap-0.5 p-2">
+        {filtered.map((network) => {
+          const isActive = network.chainId === activeChainId;
+          const isSwitching = network.chainId === switchingTo;
+
+          return (
+            <button
+              key={network.chainId}
+              onClick={() => handleSwitch(network.chainId)}
+              disabled={!!switchingTo}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors",
+                isActive
+                  ? "bg-gray-100 dark:bg-gray-800"
+                  : "hover:bg-gray-50 dark:hover:bg-gray-800/50",
+                switchingTo && !isSwitching && "opacity-40",
+              )}
+            >
+              <NetworkIcon network={network} size={28} />
+              <div className="flex-1 min-w-0">
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {network.name}
+                </span>
               </div>
-            </div>
+              <span className="font-mono text-[11px] text-gray-400 dark:text-gray-500">
+                {network.chainId}
+              </span>
+              {isSwitching ? (
+                <Loader2 size={14} className="shrink-0 animate-spin text-gray-400" />
+              ) : isActive ? (
+                <Check size={14} className="shrink-0 text-gray-900 dark:text-gray-100" />
+              ) : null}
+            </button>
+          );
+        })}
+
+        {filtered.length === 0 && (
+          <div className="px-3 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
+            No networks found
           </div>
         )}
+      </div>
+
+      {/* Footer */}
+      <div className="border-t border-gray-100 px-5 py-3 text-center dark:border-gray-800">
+        <span className="text-xs text-gray-400 dark:text-gray-500">
+          {filtered.length} network{filtered.length !== 1 ? "s" : ""}
+          {shouldShowToggle && (showTestnets ? " (testnets)" : " (mainnets)")}
+        </span>
       </div>
     </div>
   );

--- a/registry/w3-kit/network-switcher/types.ts
+++ b/registry/w3-kit/network-switcher/types.ts
@@ -1,16 +1,37 @@
 export interface Network {
+  /** Chain ID (e.g. 1 for Ethereum mainnet) */
   chainId: number;
+  /** Display name */
   name: string;
-  symbol: string;
-  currency: string;
-  rpcUrl: string;
-  blockExplorer: string;
-  logoURI: string;
+  /** Native currency symbol (e.g. "ETH") */
+  symbol?: string;
+  /** Native currency name (e.g. "Ether") */
+  currency?: string;
+  /** RPC endpoint URL */
+  rpcUrl?: string;
+  /** Block explorer URL */
+  blockExplorer?: string;
+  /** Network icon URL */
+  icon?: string;
+  /** Brand color hex (used for the dot indicator) */
+  color?: string;
+  /** Whether this is a testnet */
+  testnet?: boolean;
 }
 
 export interface NetworkSwitcherProps {
+  /** All available networks (mainnets + testnets) */
   networks: Network[];
-  testNetworks: Network[];
-  onSwitch: (chainId: number) => void;
+  /** Currently active chain ID */
+  activeChainId?: number;
+  /** Called when user selects a network */
+  onSwitch: (chainId: number) => void | Promise<void>;
+  /** Show a search input (useful when > 5 networks) */
+  searchable?: boolean;
+  /** Show testnet toggle (auto-detected from network.testnet field) */
+  showTestnetToggle?: boolean;
+  /** Currently switching to this chain ID (shows loading spinner) */
+  switchingTo?: number;
+  /** Additional CSS classes */
   className?: string;
 }


### PR DESCRIPTION
## Summary
- Rewrite from complex grid layout (270 lines of dead code) to clean compact list (190 lines)
- Parent-controlled active chain via `activeChainId` prop (was internal state)
- Merged `testNetworks` into `networks` array with `.testnet` flag
- Removed all dead code: hardcoded `networkStatus`, `gasPrice`, `latency`
- Loading state per-chain via `switchingTo` prop

## New Props API
| Prop | Type | Description |
|------|------|-------------|
| `networks` | `Network[]` | All networks (use `.testnet: true` for testnets) |
| `activeChainId` | `number` | Parent-controlled active chain |
| `onSwitch` | `(chainId) => void \| Promise<void>` | Switch callback |
| `searchable` | `boolean` | Show search input |
| `showTestnetToggle` | `boolean` | Auto-detected from `.testnet` fields |
| `switchingTo` | `number` | Chain ID currently being switched to (loading) |

## What changed
- Grid of big card buttons → compact list rows
- Internal `selectedChainId` state → parent controls via `activeChainId`
- `testNetworks` separate prop → single `networks` array with `.testnet` flag
- 80 lines of dead code removed (hardcoded status, gas, latency)
- Network details (RPC, Explorer) removed from switcher (belongs in detail view)

## Test plan
- [ ] Renders network list with active chain highlighted
- [ ] Click network → calls onSwitch
- [ ] switchingTo shows spinner on that chain, dims others
- [ ] Testnet toggle shows/hides networks with `.testnet: true`
- [ ] Search filters by name, chain ID, symbol
- [ ] Empty state when search has no matches
- [ ] Dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)