### PR TITLE
rewrite token-vesting component v2

### DIFF
--- a/registry/w3-kit/token-vesting/token-vesting.tsx
+++ b/registry/w3-kit/token-vesting/token-vesting.tsx
@@ -1,202 +1,111 @@
 "use client";
 
-import React, { useState, useMemo, useEffect } from "react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { VestingSchedule, TokenVestingProps } from "./types";
-import { calculateProgress, formatDate, isClaimable, statusConfig, animationStyles } from "./utils";
+import React from "react";
+import { Clock, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TokenVestingProps } from "./types";
+import { vestingPercent } from "./utils";
 
-const StatusBadge: React.FC<{ status: VestingSchedule["status"] }> = ({ status }) => {
-  const config = statusConfig[status];
-  return (
-    <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${config.bg} ${config.text}`}
-    >
-      {config.label}
-    </span>
-  );
+const statusColor: Record<string, string> = {
+  active: "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+  completed: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500",
+  pending: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
 };
 
-export const TokenVesting: React.FC<TokenVestingProps> = ({ vestingSchedules, onClaimTokens }) => {
-  const [claimingId, setClaimingId] = useState<string | null>(null);
-  const [expandedId, setExpandedId] = useState<string | null>(null);
-
-  useEffect(() => {
-    const styleTag = document.createElement("style");
-    styleTag.innerHTML = animationStyles;
-    document.head.appendChild(styleTag);
-
-    return () => {
-      document.head.removeChild(styleTag);
-    };
-  }, []);
-
-  const handleClaim = async (e: React.MouseEvent, scheduleId: string) => {
-    e.stopPropagation();
-    try {
-      setClaimingId(scheduleId);
-      await onClaimTokens(scheduleId);
-    } finally {
-      setClaimingId(null);
-    }
-  };
-
-  const sortedSchedules = useMemo(() => {
-    return [...vestingSchedules].sort((a, b) => {
-      const statusOrder = { active: 0, pending: 1, completed: 2 };
-      return statusOrder[a.status] - statusOrder[b.status];
-    });
-  }, [vestingSchedules]);
-
+export function TokenVesting({
+  schedules,
+  onClaim,
+  claimingId,
+  className,
+}: TokenVestingProps) {
   return (
-    <div className="space-y-4">
-      {sortedSchedules.map((schedule, index) => (
-        <Card
-          key={schedule.id}
-          className="group cursor-pointer transition-all duration-200 ease-out
-            hover:-translate-y-0.5 hover:shadow-md active:translate-y-0"
-          onClick={() => setExpandedId(expandedId === schedule.id ? null : schedule.id)}
-          style={{ animationDelay: `${index * 100}ms` }}
-        >
-          <CardHeader className="pb-3">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-3">
-                <CardTitle className="text-lg">{schedule.tokenSymbol} Vesting</CardTitle>
-                <StatusBadge status={schedule.status} />
-              </div>
-              <Button
-                variant="ghost"
-                size="icon"
-                className={`rounded-full transition-transform duration-200
-                  ${expandedId === schedule.id ? "rotate-180" : ""}`}
-              >
-                <svg
-                  className="w-5 h-5 text-muted-foreground"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M19 9l-7 7-7-7"
-                  />
-                </svg>
-              </Button>
-            </div>
-          </CardHeader>
+    <div
+      className={cn(
+        "w-full max-w-sm rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        className,
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-4">
+        <Clock className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+        <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+          Vesting
+        </h3>
+      </div>
 
-          <CardContent className="pt-0">
-            <div className="flex justify-between text-sm mb-2">
-              <span className="text-muted-foreground">Progress</span>
-              <span className="text-foreground font-medium">
-                {calculateProgress(schedule).toFixed(1)}%
-              </span>
-            </div>
-            <div className="relative w-full bg-secondary rounded-full h-2 overflow-hidden">
-              <div
-                className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent
-                  animate-shimmer"
-                style={{ "--tw-translate-x": "-100%" } as React.CSSProperties}
-              />
-              <div
-                className="bg-primary h-full rounded-full transition-all duration-700 ease-out"
-                style={{ width: `${calculateProgress(schedule)}%` }}
-              />
-            </div>
+      {/* Schedule list */}
+      <div className="space-y-1.5 px-4 pb-4">
+        {schedules.length === 0 && (
+          <p className="py-6 text-center text-sm text-gray-400 dark:text-gray-500">
+            No vesting schedules
+          </p>
+        )}
 
+        {schedules.map((schedule) => {
+          const isClaiming = claimingId === schedule.id;
+          const pct = vestingPercent(schedule.vestedAmount, schedule.totalAmount);
+          const isClaimable = schedule.status === "active" && pct < 100;
+
+          return (
             <div
-              className={`mt-4 transition-all duration-300 ease-out overflow-hidden
-                ${expandedId === schedule.id ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"}`}
+              key={schedule.id}
+              className="rounded-xl bg-gray-50 px-3 py-3 dark:bg-gray-900"
             >
-              <p className="text-sm text-muted-foreground mb-4">
-                {formatDate(schedule.startDate)} - {formatDate(schedule.endDate)}
-              </p>
-
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                <div className="bg-secondary p-4 rounded-lg transition-colors duration-200 hover:bg-secondary/80">
-                  <span className="text-muted-foreground text-sm">Total Amount</span>
-                  <p className="font-medium text-foreground mt-1">
-                    {schedule.totalAmount} {schedule.tokenSymbol}
+              {/* Top row */}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">
+                    {schedule.token}
                   </p>
+                  <span
+                    className={cn(
+                      "rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize",
+                      statusColor[schedule.status] ?? statusColor.pending,
+                    )}
+                  >
+                    {schedule.status}
+                  </span>
                 </div>
-                <div className="bg-secondary p-4 rounded-lg transition-colors duration-200 hover:bg-secondary/80">
-                  <span className="text-muted-foreground text-sm">Vested Amount</span>
-                  <p className="font-medium text-foreground mt-1">
-                    {schedule.vestedAmount} {schedule.tokenSymbol}
-                  </p>
-                </div>
-                <div className="bg-secondary p-4 rounded-lg transition-colors duration-200 hover:bg-secondary/80">
-                  <span className="text-muted-foreground text-sm">Cliff Date</span>
-                  <p className="font-medium text-foreground mt-1">
-                    {formatDate(schedule.cliffDate)}
-                  </p>
-                </div>
-                <div className="bg-secondary p-4 rounded-lg transition-colors duration-200 hover:bg-secondary/80">
-                  <span className="text-muted-foreground text-sm">Last Claimed</span>
-                  <p className="font-medium text-foreground mt-1">
-                    {schedule.lastClaimDate ? formatDate(schedule.lastClaimDate) : "Never"}
-                  </p>
-                </div>
+                <p className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                  {schedule.vestedAmount} / {schedule.totalAmount}
+                </p>
               </div>
 
-              {isClaimable(schedule) && (
-                <Button
-                  onClick={(e) => handleClaim(e, schedule.id)}
-                  disabled={claimingId === schedule.id}
-                  className="w-full mt-4"
-                >
-                  {claimingId === schedule.id ? (
-                    <>
-                      <svg
-                        className="animate-spin -ml-1 mr-2 h-4 w-4"
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                      >
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                        />
-                      </svg>
-                      Claiming Tokens...
-                    </>
-                  ) : (
-                    <>
-                      <svg
-                        className="mr-2 h-4 w-4"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                        />
-                      </svg>
-                      Claim Available Tokens
-                    </>
+              {/* Progress bar */}
+              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                <div
+                  className="h-full rounded-full bg-gray-900 transition-all duration-500 dark:bg-white"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+
+              {/* Dates */}
+              <div className="mt-2 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                <span>Cliff: {schedule.cliffDate}</span>
+                <span>End: {schedule.endDate}</span>
+              </div>
+
+              {/* Claim button */}
+              {isClaimable && (
+                <button
+                  onClick={() => onClaim?.(schedule.id)}
+                  disabled={isClaiming}
+                  className={cn(
+                    "mt-2.5 flex w-full items-center justify-center gap-2 rounded-lg bg-gray-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200",
+                    isClaiming && "cursor-not-allowed opacity-60",
                   )}
-                </Button>
+                >
+                  {isClaiming ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    "Claim"
+                  )}
+                </button>
               )}
             </div>
-          </CardContent>
-        </Card>
-      ))}
+          );
+        })}
+      </div>
     </div>
   );
-};
-
-export default TokenVesting;
+}

--- a/registry/w3-kit/token-vesting/types.ts
+++ b/registry/w3-kit/token-vesting/types.ts
@@ -1,17 +1,16 @@
 export interface VestingSchedule {
   id: string;
-  tokenSymbol: string;
+  token: string;
   totalAmount: string;
   vestedAmount: string;
-  startDate: number;
-  endDate: number;
-  cliffDate: number;
-  lastClaimDate: number | null;
-  beneficiary: string;
+  cliffDate: string;
+  endDate: string;
   status: "active" | "completed" | "pending";
 }
 
 export interface TokenVestingProps {
-  vestingSchedules: VestingSchedule[];
-  onClaimTokens: (scheduleId: string) => Promise<void>;
+  schedules: VestingSchedule[];
+  onClaim?: (scheduleId: string) => void;
+  claimingId?: string;
+  className?: string;
 }

--- a/registry/w3-kit/token-vesting/utils.ts
+++ b/registry/w3-kit/token-vesting/utils.ts
@@ -1,54 +1,5 @@
-import { VestingSchedule } from "./types";
-
-export function calculateProgress(schedule: VestingSchedule): number {
-  const now = Date.now();
-  const total = schedule.endDate - schedule.startDate;
-  const current = now - schedule.startDate;
-  return Math.min(Math.max((current / total) * 100, 0), 100);
+export function vestingPercent(vested: string, total: string): number {
+  const v = parseFloat(vested) || 0;
+  const t = parseFloat(total) || 1;
+  return Math.min(Math.round((v / t) * 100), 100);
 }
-
-export function formatDate(timestamp: number): string {
-  return new Date(timestamp).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-export function isClaimable(schedule: VestingSchedule): boolean {
-  const now = Date.now();
-  return (
-    schedule.status === "active" &&
-    now >= schedule.cliffDate &&
-    parseFloat(schedule.vestedAmount) < parseFloat(schedule.totalAmount)
-  );
-}
-
-export const statusConfig = {
-  active: {
-    bg: "bg-green-100 dark:bg-green-900/30",
-    text: "text-green-800 dark:text-green-400",
-    label: "Active",
-  },
-  completed: {
-    bg: "bg-gray-100 dark:bg-gray-900/30",
-    text: "text-gray-800 dark:text-gray-400",
-    label: "Completed",
-  },
-  pending: {
-    bg: "bg-yellow-100 dark:bg-yellow-900/30",
-    text: "text-yellow-800 dark:text-yellow-400",
-    label: "Pending",
-  },
-};
-
-export const animationStyles = `
-  @keyframes shimmer {
-    from { transform: translateX(-100%); }
-    to { transform: translateX(100%); }
-  }
-
-  .animate-shimmer {
-    animation: shimmer 2s infinite;
-  }
-`;


### PR DESCRIPTION
## Summary
- Rewrote types with simplified `VestingSchedule` and `TokenVestingProps`
- Minimal utils (just `vestingPercent`)
- Pure UI component: header with Clock icon + "Vesting", schedule list with progress bar, cliff/end dates, status badges, claim button for active schedules
- Follows design system: `cn`, lucide icons, `rounded-2xl` card, `max-w-sm`, `rounded-xl` rows