### PR TITLE
feat: redesign SmartContractScanner — pure UI, no fake results

### DIFF
--- a/components/smart-contract-scanner/SmartContractScanner.tsx
+++ b/components/smart-contract-scanner/SmartContractScanner.tsx
@@ -1,216 +1,171 @@
 "use client";
 
-import React, { useState } from "react";
-import { Search, Loader2, ShieldCheck, ShieldAlert, ShieldX } from "lucide-react";
+import { useState } from "react";
+import {
+  Shield,
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  Search,
+  Loader2,
+} from "lucide-react";
 import { cn } from "../../lib/utils";
-import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { SecurityCheck, SmartContractScannerProps } from "./types";
-import { isValidAddress, getMockChecks } from "./utils";
+import { SmartContractScannerProps, SecurityCheck } from "./types";
+import { truncateAddress } from "./utils";
 
-export type { SecurityCheck, SmartContractScannerProps };
+const statusIcon = {
+  safe: ShieldCheck,
+  warning: ShieldAlert,
+  danger: ShieldX,
+} as const;
 
-const statusConfig = {
-  safe: {
-    icon: ShieldCheck,
-    label: "Safe",
-    color: "text-green-600 dark:text-green-400",
-    bg: "bg-green-50 dark:bg-green-950",
-    bar: "bg-green-500",
-  },
-  warning: {
-    icon: ShieldAlert,
-    label: "Warning",
-    color: "text-amber-600 dark:text-amber-400",
-    bg: "bg-amber-50 dark:bg-amber-950",
-    bar: "bg-amber-500",
-  },
-  danger: {
-    icon: ShieldX,
-    label: "Danger",
-    color: "text-red-600 dark:text-red-400",
-    bg: "bg-red-50 dark:bg-red-950",
-    bar: "bg-red-500",
-  },
-};
+const statusColor = {
+  safe: "text-green-600 dark:text-green-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  danger: "text-red-600 dark:text-red-400",
+} as const;
 
-export function SmartContractScanner({ className, onScan }: SmartContractScannerProps) {
-  const [address, setAddress] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [checks, setChecks] = useState<SecurityCheck[]>([]);
-  const [scanned, setScanned] = useState(false);
-  const [touched, setTouched] = useState(false);
+const statusBadge = {
+  safe: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400",
+  warning: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+  danger: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+} as const;
 
-  const isValid = isValidAddress(address);
-  const showError = touched && address.length > 0 && !isValid;
+function scoreColor(score: number) {
+  if (score > 70) return "border-green-500 text-green-600 dark:text-green-400";
+  if (score > 40) return "border-amber-500 text-amber-600 dark:text-amber-400";
+  return "border-red-500 text-red-600 dark:text-red-400";
+}
 
-  const handleScan = async () => {
-    if (!isValid) return;
-    setLoading(true);
-    onScan?.(address);
-    await new Promise((r) => setTimeout(r, 1500));
-    setChecks(getMockChecks());
-    setScanned(true);
-    setLoading(false);
+export function SmartContractScanner({
+  address,
+  score,
+  checks,
+  onScan,
+  loading = false,
+  className,
+}: SmartContractScannerProps) {
+  const [input, setInput] = useState("");
+  const hasResults = score !== undefined && checks !== undefined;
+  const passedCount = checks?.filter((c) => c.status === "safe").length ?? 0;
+
+  const handleScan = () => {
+    const value = input.trim();
+    if (value && onScan) onScan(value);
   };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && isValid && !loading) handleScan();
-  };
-
-  const score = scanned
-    ? Math.round((checks.filter((c) => c.status === "safe").length / checks.length) * 100)
-    : 0;
-  const safeCount = checks.filter((c) => c.status === "safe").length;
-  const warnCount = checks.filter((c) => c.status === "warning").length;
-  const dangerCount = checks.filter((c) => c.status === "danger").length;
 
   return (
     <div
       className={cn(
-        "rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 overflow-hidden",
+        "max-w-sm rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
         className,
       )}
     >
       {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-800">
-        <p className="text-[11px] uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
-          Contract Scanner
-        </p>
+      <div className="flex items-center gap-2 px-4 pt-4 pb-3">
+        <Shield className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        <span className="text-sm font-medium text-gray-900 dark:text-white">
+          Scanner
+        </span>
+        {address && (
+          <span className="ml-auto rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {truncateAddress(address)}
+          </span>
+        )}
       </div>
 
-      <div className="p-4 space-y-4">
-        {/* Input */}
-        <div>
+      <div className="px-4 pb-4 space-y-4">
+        {/* Input state — no results yet */}
+        {!hasResults && !loading && (
           <div className="flex gap-2">
-            <Input
-              placeholder="Contract address (0x...)"
-              value={address}
-              onChange={(e) => {
-                setAddress(e.target.value);
-                setTouched(true);
-              }}
-              onKeyDown={handleKeyDown}
-              className={cn("font-mono text-xs", showError && "border-red-300 dark:border-red-800")}
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleScan()}
+              placeholder="0x..."
+              className="flex-1 rounded-lg border border-gray-200 bg-transparent px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
             />
-            <Button onClick={handleScan} disabled={!isValid || loading} size="sm">
-              {loading ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Search className="h-4 w-4" />
-              )}
-            </Button>
+            <button
+              onClick={handleScan}
+              disabled={!input.trim()}
+              className="rounded-lg bg-gray-900 px-3 py-2 text-white transition-colors hover:bg-gray-800 disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            >
+              <Search className="h-4 w-4" />
+            </button>
           </div>
-          {showError && (
-            <p className="text-[11px] text-red-600 dark:text-red-400 mt-1">
-              Enter a valid Ethereum address (0x + 40 hex characters)
-            </p>
-          )}
-        </div>
-
-        {/* Pre-scan hint */}
-        {!scanned && !loading && (
-          <p className="text-xs text-gray-400 dark:text-gray-500 text-center py-2">
-            Enter a contract address to analyze its security, ownership, and potential risks
-          </p>
         )}
 
         {/* Loading state */}
         {loading && (
-          <div className="flex flex-col items-center py-6 gap-2">
-            <Loader2 className="h-6 w-6 text-gray-400 animate-spin" />
-            <p className="text-xs text-gray-500 dark:text-gray-400">Analyzing contract…</p>
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
           </div>
         )}
 
         {/* Results */}
-        {scanned && !loading && (
+        {hasResults && !loading && (
           <>
-            {/* Score */}
-            <div className="rounded-lg bg-gray-50 dark:bg-gray-900 p-3">
-              <div className="flex items-center justify-between mb-2">
-                <p className="text-[11px] uppercase tracking-wider font-medium text-gray-500 dark:text-gray-400">
-                  Security Score
-                </p>
-                <div className="flex items-center gap-2 text-[11px]">
-                  {safeCount > 0 && (
-                    <span className="text-green-600 dark:text-green-400">{safeCount} safe</span>
-                  )}
-                  {warnCount > 0 && (
-                    <span className="text-amber-600 dark:text-amber-400">{warnCount} warning</span>
-                  )}
-                  {dangerCount > 0 && (
-                    <span className="text-red-600 dark:text-red-400">{dangerCount} danger</span>
-                  )}
-                </div>
-              </div>
-              <p
+            {/* Score circle */}
+            <div className="flex justify-center py-2">
+              <div
                 className={cn(
-                  "text-2xl font-semibold tabular-nums",
-                  score >= 80
-                    ? "text-green-600 dark:text-green-400"
-                    : score >= 50
-                      ? "text-amber-600 dark:text-amber-400"
-                      : "text-red-600 dark:text-red-400",
+                  "flex h-20 w-20 items-center justify-center rounded-full border-4",
+                  scoreColor(score),
                 )}
               >
-                {score}/100
-              </p>
-              {/* Score bar */}
-              <div className="flex h-1.5 rounded-full overflow-hidden mt-2 bg-gray-200 dark:bg-gray-800">
-                <div
-                  className={cn(
-                    "h-full rounded-full transition-all duration-500",
-                    score >= 80 ? "bg-green-500" : score >= 50 ? "bg-amber-500" : "bg-red-500",
-                  )}
-                  style={{ width: `${score}%` }}
-                />
+                <span className="text-2xl font-bold tabular-nums">{score}</span>
               </div>
             </div>
 
-            {/* Checks list */}
-            <div className="space-y-1">
-              {checks.map((check) => {
-                const config = statusConfig[check.status];
-                const Icon = config.icon;
+            {/* Check list */}
+            <ul className="space-y-1.5">
+              {checks.map((check: SecurityCheck) => {
+                const Icon = statusIcon[check.status];
                 return (
-                  <div
-                    key={check.id}
-                    className="flex items-start gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors duration-150"
+                  <li
+                    key={check.name}
+                    className="flex items-start gap-2.5 rounded-lg px-2 py-2"
                   >
-                    <div
-                      className={cn(
-                        "flex-shrink-0 w-6 h-6 rounded-md flex items-center justify-center mt-0.5",
-                        config.bg,
-                      )}
-                    >
-                      <Icon className={cn("h-3.5 w-3.5", config.color)} />
-                    </div>
-                    <div className="min-w-0">
+                    <Icon
+                      className={cn("mt-0.5 h-4 w-4 shrink-0", statusColor[check.status])}
+                    />
+                    <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white">
+                        <span className="text-sm font-medium text-gray-900 dark:text-white">
                           {check.name}
-                        </p>
+                        </span>
                         <span
                           className={cn(
-                            "text-[10px] font-medium uppercase tracking-wider",
-                            config.color,
+                            "rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none",
+                            statusBadge[check.status],
                           )}
                         >
-                          {config.label}
+                          {check.status}
                         </span>
                       </div>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                        {check.description}
-                      </p>
+                      {check.description && (
+                        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                          {check.description}
+                        </p>
+                      )}
                     </div>
-                  </div>
+                  </li>
                 );
               })}
-            </div>
+            </ul>
           </>
         )}
       </div>
+
+      {/* Footer */}
+      {hasResults && !loading && (
+        <div className="border-t border-gray-100 px-4 py-2.5 dark:border-gray-800">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {passedCount} check{passedCount !== 1 ? "s" : ""} passed
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/smart-contract-scanner/types.ts
+++ b/components/smart-contract-scanner/types.ts
@@ -1,11 +1,16 @@
+export type CheckStatus = "safe" | "warning" | "danger";
+
 export interface SecurityCheck {
-  id: string;
   name: string;
-  status: "safe" | "warning" | "danger";
-  description: string;
+  status: CheckStatus;
+  description?: string;
 }
 
 export interface SmartContractScannerProps {
-  className?: string;
+  address?: string;
+  score?: number;
+  checks?: SecurityCheck[];
   onScan?: (address: string) => void;
+  loading?: boolean;
+  className?: string;
 }

--- a/components/smart-contract-scanner/utils.ts
+++ b/components/smart-contract-scanner/utils.ts
@@ -1,40 +1,4 @@
-import { SecurityCheck } from "./types";
-
-export function isValidAddress(address: string): boolean {
-  return /^0x[a-fA-F0-9]{40}$/.test(address);
-}
-
-export function getMockChecks(): SecurityCheck[] {
-  return [
-    {
-      id: "1",
-      name: "Ownership Renounced",
-      status: "safe",
-      description: "Contract ownership has been renounced",
-    },
-    {
-      id: "2",
-      name: "No Proxy Pattern",
-      status: "safe",
-      description: "No upgradeable proxy detected",
-    },
-    {
-      id: "3",
-      name: "Reentrancy Guard",
-      status: "safe",
-      description: "Protected against reentrancy attacks",
-    },
-    {
-      id: "4",
-      name: "Unlimited Minting",
-      status: "warning",
-      description: "Token has no max supply cap",
-    },
-    {
-      id: "5",
-      name: "External Calls",
-      status: "danger",
-      description: "Unvalidated external contract calls found",
-    },
-  ];
+export function truncateAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }

--- a/packages/create-w3-kit/components/smart-contract-scanner/SmartContractScanner.tsx
+++ b/packages/create-w3-kit/components/smart-contract-scanner/SmartContractScanner.tsx
@@ -1,786 +1,181 @@
-import React, { useState, useRef } from "react";
+"use client";
+
+import { useState } from "react";
 import {
-  Search,
   Shield,
-  AlertTriangle,
-  Check,
-  X,
-  ExternalLink,
-  Copy,
-  ChevronDown,
-  ChevronUp,
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  Search,
+  Loader2,
 } from "lucide-react";
 
-// Define error types for better error handling
-export enum ContractError {
-  INVALID_ADDRESS = "Invalid contract address format",
-  NOT_FOUND = "Contract not found",
-  NOT_VERIFIED = "Contract is not verified",
-  NETWORK_ERROR = "Network connection error",
-  SCAN_FAILED = "Contract scanning failed",
-  RATE_LIMIT = "API rate limit exceeded",
-  TIMEOUT = "Request timeout",
-  UNKNOWN = "An unknown error occurred",
-}
+export type CheckStatus = "safe" | "warning" | "danger";
 
-interface SecurityCheck {
-  id: string;
+export interface SecurityCheck {
   name: string;
-  status: "safe" | "warning" | "danger";
-  description: string;
-  details?: string;
+  status: CheckStatus;
+  description?: string;
 }
 
-interface ContractFunction {
-  name: string;
-  type: "read" | "write";
-  inputs: { name: string; type: string }[];
-  outputs: { type: string }[];
-  stateMutability: string;
-}
-
-interface ContractInfo {
-  name: string;
-  address: string;
-  network: string;
-  verified: boolean;
-  license: string;
-  compiler: string;
-  securityScore: number;
-  checks: SecurityCheck[];
-  functions: ContractFunction[];
-  sourceCode?: string;
-}
-
-interface SmartContractScannerProps {
-  className?: string;
-  variant?: "default" | "compact";
+export interface SmartContractScannerProps {
+  address?: string;
+  score?: number;
+  checks?: SecurityCheck[];
   onScan?: (address: string) => void;
-  onError?: (error: ContractError) => void; // Add error callback
+  loading?: boolean;
+  className?: string;
 }
 
-export const SmartContractScanner: React.FC<SmartContractScannerProps> = ({
-  className = "",
-  variant = "default",
+function truncateAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+const statusIcon = {
+  safe: ShieldCheck,
+  warning: ShieldAlert,
+  danger: ShieldX,
+} as const;
+
+const statusColor = {
+  safe: "text-green-600 dark:text-green-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  danger: "text-red-600 dark:text-red-400",
+} as const;
+
+const statusBadge = {
+  safe: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400",
+  warning: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+  danger: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+} as const;
+
+function scoreColor(score: number) {
+  if (score > 70) return "border-green-500 text-green-600 dark:text-green-400";
+  if (score > 40) return "border-amber-500 text-amber-600 dark:text-amber-400";
+  return "border-red-500 text-red-600 dark:text-red-400";
+}
+
+export function SmartContractScanner({
+  address,
+  score,
+  checks,
   onScan,
-  onError,
-}) => {
-  const [address, setAddress] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [contractInfo, setContractInfo] = useState<ContractInfo | null>(null);
-  const [activeTab, setActiveTab] = useState<"overview" | "functions" | "code">("overview");
-  const [error, setError] = useState<ContractError | null>(null);
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const [expandedCode, setExpandedCode] = useState(false);
-  const [copySuccess, setCopySuccess] = useState(false);
-  const codePreviewRef = useRef<HTMLDivElement>(null);
+  loading = false,
+  className = "",
+}: SmartContractScannerProps) {
+  const [input, setInput] = useState("");
+  const hasResults = score !== undefined && checks !== undefined;
+  const passedCount = checks?.filter((c) => c.status === "safe").length ?? 0;
 
-  // Validate Ethereum address format
-  const isValidAddress = (address: string): boolean => {
-    return /^0x[a-fA-F0-9]{40}$/.test(address);
+  const handleScan = () => {
+    const value = input.trim();
+    if (value && onScan) onScan(value);
   };
-
-  // Handle address input change with validation
-  const handleAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setAddress(value);
-
-    // Clear errors when input changes
-    setValidationError(null);
-    setError(null);
-
-    // Validate address format if not empty
-    if (value && !isValidAddress(value)) {
-      setValidationError(
-        "Please enter a valid Ethereum address (0x followed by 40 hex characters)",
-      );
-    }
-  };
-
-  const handleScan = async () => {
-    if (!address) return;
-
-    // Validate address before scanning
-    if (!isValidAddress(address)) {
-      const errorMsg = ContractError.INVALID_ADDRESS;
-      setError(errorMsg);
-      onError?.(errorMsg);
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-    setValidationError(null);
-
-    try {
-      // Mock API call - replace with actual contract scanning logic
-      await new Promise((resolve, reject) => {
-        // Simulate random failures for testing (20% chance)
-        const shouldFail = Math.random() < 0.2;
-
-        setTimeout(() => {
-          if (shouldFail) {
-            reject(new Error("SCAN_FAILED"));
-          } else {
-            resolve(true);
-          }
-        }, 1500);
-      });
-
-      onScan?.(address);
-
-      // Mock contract data with source code
-      setContractInfo({
-        name: "Example Token",
-        address: address,
-        network: "Ethereum Mainnet",
-        verified: true,
-        license: "MIT",
-        compiler: "v0.8.17+commit.8df45f5f",
-        securityScore: 85,
-        checks: [
-          {
-            id: "1",
-            name: "Reentrancy Guard",
-            status: "safe",
-            description: "Contract is protected against reentrancy attacks",
-          },
-          {
-            id: "2",
-            name: "Access Control",
-            status: "warning",
-            description: "Owner has significant privileges",
-          },
-        ],
-        functions: [
-          {
-            name: "balanceOf",
-            type: "read",
-            inputs: [{ name: "account", type: "address" }],
-            outputs: [{ type: "uint256" }],
-            stateMutability: "view",
-          },
-          {
-            name: "transfer",
-            type: "write",
-            inputs: [
-              { name: "to", type: "address" },
-              { name: "amount", type: "uint256" },
-            ],
-            outputs: [{ type: "bool" }],
-            stateMutability: "nonpayable",
-          },
-        ],
-        // Add sample source code
-        sourceCode: `// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
-
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-
-/**
- * @title Example Token
- * @dev A simple ERC20 token with additional security features
- */
-contract ExampleToken is ERC20, Ownable, ReentrancyGuard {
-    uint256 private _maxSupply;
-    mapping(address => bool) private _blacklisted;
-    
-    event AddressBlacklisted(address indexed account);
-    event AddressUnblacklisted(address indexed account);
-    
-    constructor() ERC20("Example Token", "EXT") {
-        _maxSupply = 1000000000 * 10**decimals();
-        _mint(msg.sender, 100000000 * 10**decimals());
-    }
-    
-    function mint(address to, uint256 amount) external onlyOwner {
-        require(totalSupply() + amount <= _maxSupply, "Exceeds max supply");
-        _mint(to, amount);
-    }
-    
-    function blacklistAddress(address account) external onlyOwner {
-        _blacklisted[account] = true;
-        emit AddressBlacklisted(account);
-    }
-    
-    function unblacklistAddress(address account) external onlyOwner {
-        _blacklisted[account] = false;
-        emit AddressUnblacklisted(account);
-    }
-    
-    function isBlacklisted(address account) external view returns (bool) {
-        return _blacklisted[account];
-    }
-    
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override nonReentrant {
-        require(!_blacklisted[from] && !_blacklisted[to], "Blacklisted address");
-        super._beforeTokenTransfer(from, to, amount);
-    }
-}`,
-      });
-    } catch (err) {
-      // Map error messages to specific error types
-      let errorType = ContractError.UNKNOWN;
-
-      if (err instanceof Error) {
-        switch (err.message) {
-          case "NOT_FOUND":
-            errorType = ContractError.NOT_FOUND;
-            break;
-          case "NOT_VERIFIED":
-            errorType = ContractError.NOT_VERIFIED;
-            break;
-          case "NETWORK_ERROR":
-            errorType = ContractError.NETWORK_ERROR;
-            break;
-          case "SCAN_FAILED":
-            errorType = ContractError.SCAN_FAILED;
-            break;
-          case "RATE_LIMIT":
-            errorType = ContractError.RATE_LIMIT;
-            break;
-          case "TIMEOUT":
-            errorType = ContractError.TIMEOUT;
-            break;
-        }
-      }
-
-      setError(errorType);
-      onError?.(errorType);
-      setContractInfo(null);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const getStatusColor = (status: SecurityCheck["status"]) => {
-    switch (status) {
-      case "safe":
-        return "text-green-500 dark:text-green-400";
-      case "warning":
-        return "text-yellow-500 dark:text-yellow-400";
-      case "danger":
-        return "text-red-500 dark:text-red-400";
-      default:
-        return "text-gray-500 dark:text-gray-400";
-    }
-  };
-
-  // Enhanced copy to clipboard with success feedback
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        setCopySuccess(true);
-        setTimeout(() => setCopySuccess(false), 2000);
-        console.log("Copied to clipboard");
-      })
-      .catch((err) => {
-        console.error("Failed to copy: ", err);
-      });
-  };
-
-  // Function to get a preview of the source code
-  const getCodePreview = (sourceCode: string, maxLines = 15): string => {
-    const lines = sourceCode.split("\n");
-    if (lines.length <= maxLines) return sourceCode;
-
-    return lines.slice(0, maxLines).join("\n") + "\n...";
-  };
-
-  if (variant === "compact") {
-    return (
-      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4 ${className}`}>
-        <div className="space-y-4">
-          <div className="relative">
-            <input
-              type="text"
-              value={address}
-              onChange={handleAddressChange}
-              placeholder="Enter contract address"
-              className={`w-full px-4 py-2 pl-10 text-sm border ${
-                validationError
-                  ? "border-red-300 dark:border-red-700"
-                  : "border-gray-200 dark:border-gray-700"
-              } rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white
-                placeholder-gray-500 dark:placeholder-gray-400
-                focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
-              disabled={isLoading}
-            />
-            <Search className="absolute left-3 top-2.5 w-4 h-4 text-gray-400 dark:text-gray-500" />
-          </div>
-
-          {validationError && (
-            <p className="text-sm text-red-500 dark:text-red-400">{validationError}</p>
-          )}
-
-          <button
-            onClick={handleScan}
-            disabled={!address || isLoading || !!validationError}
-            className="w-full px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 
-              disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm"
-          >
-            {isLoading ? (
-              <div className="flex items-center justify-center space-x-2">
-                <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
-                <span>Scanning...</span>
-              </div>
-            ) : (
-              "Scan Contract"
-            )}
-          </button>
-
-          {error && (
-            <div className="p-3 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg flex items-start space-x-2">
-              <AlertTriangle className="w-4 h-4 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
-            </div>
-          )}
-
-          {contractInfo && (
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium text-gray-900 dark:text-white">
-                  Security Score
-                </span>
-                <span
-                  className={`text-sm font-medium ${
-                    contractInfo.securityScore >= 80
-                      ? "text-green-500"
-                      : contractInfo.securityScore >= 60
-                        ? "text-yellow-500"
-                        : "text-red-500"
-                  }`}
-                >
-                  {contractInfo.securityScore}/100
-                </span>
-              </div>
-
-              <div className="text-sm text-gray-500 dark:text-gray-400">
-                {contractInfo.checks.length} security checks completed
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  }
 
   return (
-    <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-lg ${className}`}>
-      <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
-          Smart Contract Scanner
-        </h2>
-
-        <div className="space-y-4">
-          <div className="relative">
-            <input
-              type="text"
-              value={address}
-              onChange={handleAddressChange}
-              placeholder="Enter contract address"
-              className={`w-full px-4 py-3 pl-11 text-sm border ${
-                validationError
-                  ? "border-red-300 dark:border-red-700"
-                  : "border-gray-200 dark:border-gray-700"
-              } rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white
-                placeholder-gray-500 dark:placeholder-gray-400
-                focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400`}
-              disabled={isLoading}
-            />
-            <Search className="absolute left-3 top-3.5 w-5 h-5 text-gray-400 dark:text-gray-500" />
-          </div>
-
-          {validationError && (
-            <p className="text-sm text-red-500 dark:text-red-400">{validationError}</p>
-          )}
-
-          <button
-            onClick={handleScan}
-            disabled={!address || isLoading || !!validationError}
-            className="w-full px-4 py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 
-              disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm font-medium"
-          >
-            {isLoading ? (
-              <div className="flex items-center justify-center space-x-2">
-                <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
-                <span>Scanning Contract...</span>
-              </div>
-            ) : (
-              "Scan Contract"
-            )}
-          </button>
-
-          {error && (
-            <div
-              className="p-4 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 
-              rounded-lg flex items-start space-x-3"
-            >
-              <AlertTriangle className="w-5 h-5 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" />
-              <div className="flex-1">
-                <h4 className="text-sm font-medium text-red-800 dark:text-red-300">Error</h4>
-                <p className="mt-1 text-sm text-red-700 dark:text-red-400">{error}</p>
-              </div>
-            </div>
-          )}
-        </div>
+    <div
+      className={`max-w-sm rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950 ${className}`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 pt-4 pb-3">
+        <Shield className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        <span className="text-sm font-medium text-gray-900 dark:text-white">
+          Scanner
+        </span>
+        {address && (
+          <span className="ml-auto rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {truncateAddress(address)}
+          </span>
+        )}
       </div>
 
-      {contractInfo && (
-        <>
-          <div className="border-b border-gray-200 dark:border-gray-700">
-            <div className="flex space-x-4 px-6 overflow-x-auto">
-              {(["overview", "functions", "code"] as const).map((tab) => (
-                <button
-                  key={tab}
-                  onClick={() => setActiveTab(tab)}
-                  className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
-                    activeTab === tab
-                      ? "border-blue-500 text-blue-500"
-                      : "border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
-                  }`}
-                >
-                  {tab.charAt(0).toUpperCase() + tab.slice(1)}
-                </button>
-              ))}
+      <div className="px-4 pb-4 space-y-4">
+        {/* Input state */}
+        {!hasResults && !loading && (
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleScan()}
+              placeholder="0x..."
+              className="flex-1 rounded-lg border border-gray-200 bg-transparent px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
+            />
+            <button
+              onClick={handleScan}
+              disabled={!input.trim()}
+              className="rounded-lg bg-gray-900 px-3 py-2 text-white transition-colors hover:bg-gray-800 disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            >
+              <Search className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Loading state */}
+        {loading && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          </div>
+        )}
+
+        {/* Results */}
+        {hasResults && !loading && (
+          <>
+            <div className="flex justify-center py-2">
+              <div
+                className={`flex h-20 w-20 items-center justify-center rounded-full border-4 ${scoreColor(score)}`}
+              >
+                <span className="text-2xl font-bold tabular-nums">{score}</span>
+              </div>
             </div>
-          </div>
 
-          <div className="p-6">
-            {activeTab === "overview" && (
-              <div className="space-y-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                        Contract Name
-                      </h3>
-                      <p className="mt-1 text-sm text-gray-900 dark:text-white">
-                        {contractInfo.name}
-                      </p>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                        Contract Address
-                      </h3>
-                      <div className="mt-1 flex items-center">
-                        <p className="text-sm text-gray-900 dark:text-white truncate max-w-[180px] sm:max-w-xs">
-                          {contractInfo.address}
+            <ul className="space-y-1.5">
+              {checks.map((check: SecurityCheck) => {
+                const Icon = statusIcon[check.status];
+                return (
+                  <li
+                    key={check.name}
+                    className="flex items-start gap-2.5 rounded-lg px-2 py-2"
+                  >
+                    <Icon
+                      className={`mt-0.5 h-4 w-4 shrink-0 ${statusColor[check.status]}`}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-gray-900 dark:text-white">
+                          {check.name}
+                        </span>
+                        <span
+                          className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none ${statusBadge[check.status]}`}
+                        >
+                          {check.status}
+                        </span>
+                      </div>
+                      {check.description && (
+                        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                          {check.description}
                         </p>
-                        <button
-                          onClick={() => copyToClipboard(contractInfo.address)}
-                          className="ml-2 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 
-                            dark:hover:text-gray-200 transition-colors"
-                          title="Copy address"
-                        >
-                          <Copy className="w-4 h-4" />
-                        </button>
-                      </div>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                        Network
-                      </h3>
-                      <p className="mt-1 text-sm text-gray-900 dark:text-white">
-                        {contractInfo.network}
-                      </p>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                        Compiler Version
-                      </h3>
-                      <p className="mt-1 text-sm text-gray-900 dark:text-white">
-                        {contractInfo.compiler}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                        Security Score
-                      </h3>
-                      <div className="mt-1 flex items-center">
-                        <span
-                          className={`text-2xl font-bold ${
-                            contractInfo.securityScore >= 80
-                              ? "text-green-500"
-                              : contractInfo.securityScore >= 60
-                                ? "text-yellow-500"
-                                : "text-red-500"
-                          }`}
-                        >
-                          {contractInfo.securityScore}
-                        </span>
-                        <span className="text-sm text-gray-500 dark:text-gray-400 ml-1">/100</span>
-                      </div>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                        Verification Status
-                      </h3>
-                      <div className="mt-1 flex items-center">
-                        {contractInfo.verified ? (
-                          <Check className="w-4 h-4 text-green-500" />
-                        ) : (
-                          <X className="w-4 h-4 text-red-500" />
-                        )}
-                        <span className="ml-2 text-sm text-gray-900 dark:text-white">
-                          {contractInfo.verified ? "Verified" : "Unverified"}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  <h3 className="text-sm font-medium text-gray-900 dark:text-white">
-                    Security Checks
-                  </h3>
-                  <div className="space-y-3">
-                    {contractInfo.checks.map((check) => (
-                      <div
-                        key={check.id}
-                        className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
-                      >
-                        <div className="flex items-start justify-between">
-                          <div className="space-y-1">
-                            <div className="flex items-center space-x-2">
-                              {check.status === "safe" && (
-                                <Shield className={`w-4 h-4 ${getStatusColor(check.status)}`} />
-                              )}
-                              {check.status === "warning" && (
-                                <AlertTriangle
-                                  className={`w-4 h-4 ${getStatusColor(check.status)}`}
-                                />
-                              )}
-                              {check.status === "danger" && (
-                                <AlertTriangle
-                                  className={`w-4 h-4 ${getStatusColor(check.status)}`}
-                                />
-                              )}
-                              <span className="font-medium text-gray-900 dark:text-white">
-                                {check.name}
-                              </span>
-                            </div>
-                            <p className="text-sm text-gray-500 dark:text-gray-400">
-                              {check.description}
-                            </p>
-                          </div>
-                          <span className={`text-sm font-medium ${getStatusColor(check.status)}`}>
-                            {check.status.toUpperCase()}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {activeTab === "functions" && (
-              <div className="space-y-4">
-                {contractInfo.functions.map((func, index) => (
-                  <div
-                    key={`${func.name}-${index}`}
-                    className="p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
-                  >
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center space-x-2">
-                        <span
-                          className={`px-2 py-1 text-xs font-medium rounded-full ${
-                            func.type === "read"
-                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                              : "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
-                          }`}
-                        >
-                          {func.type.toUpperCase()}
-                        </span>
-                        <span className="font-medium text-gray-900 dark:text-white">
-                          {func.name}
-                        </span>
-                      </div>
-                      <span className="text-sm text-gray-500 dark:text-gray-400">
-                        {func.stateMutability}
-                      </span>
-                    </div>
-
-                    <div className="space-y-2">
-                      {func.inputs.length > 0 && (
-                        <div>
-                          <span className="text-sm text-gray-500 dark:text-gray-400">Inputs:</span>
-                          <div className="mt-1 space-y-1">
-                            {func.inputs.map((input, i) => (
-                              <div
-                                key={`${input.name}-${i}`}
-                                className="text-sm text-gray-900 dark:text-white"
-                              >
-                                {input.name}: {input.type}
-                              </div>
-                            ))}
-                          </div>
-                        </div>
                       )}
-
-                      <div>
-                        <span className="text-sm text-gray-500 dark:text-gray-400">Returns:</span>
-                        <div className="mt-1 text-sm text-gray-900 dark:text-white">
-                          {func.outputs.map((output) => output.type).join(", ")}
-                        </div>
-                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+      </div>
 
-            {activeTab === "code" && contractInfo.sourceCode && (
-              <div className="space-y-4">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between pb-4 border-b border-gray-200 dark:border-gray-700">
-                  <div className="mb-2 sm:mb-0">
-                    <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                      Contract Address
-                    </h3>
-                    <div className="mt-1 flex items-center">
-                      <p className="text-sm text-gray-900 dark:text-white truncate max-w-[200px] sm:max-w-xs md:max-w-md">
-                        {contractInfo.address}
-                      </p>
-                      <button
-                        onClick={() => copyToClipboard(contractInfo.address)}
-                        className="ml-2 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 
-                          dark:hover:text-gray-200 transition-colors"
-                        title="Copy address"
-                      >
-                        <Copy className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </div>
-                  <div className="flex space-x-2">
-                    <button
-                      onClick={() => copyToClipboard(contractInfo.sourceCode!)}
-                      className={`px-3 py-1.5 text-xs font-medium ${
-                        copySuccess
-                          ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                          : "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
-                      } rounded-md transition-colors flex items-center`}
-                      title="Copy source code"
-                    >
-                      {copySuccess ? (
-                        <>
-                          <Check className="w-3.5 h-3.5 mr-1.5" />
-                          Copied!
-                        </>
-                      ) : (
-                        <>
-                          <Copy className="w-3.5 h-3.5 mr-1.5" />
-                          Copy Code
-                        </>
-                      )}
-                    </button>
-                    <a
-                      href={`https://etherscan.io/address/${contractInfo.address}#code`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300 
-                        bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 
-                        rounded-md transition-colors flex items-center"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-                      View on Etherscan
-                    </a>
-                  </div>
-                </div>
-
-                {/* Code preview with show more button */}
-                <div className="relative">
-                  <div
-                    ref={codePreviewRef}
-                    className={`p-4 bg-gray-50 dark:bg-gray-900 rounded-lg overflow-x-auto text-sm ${
-                      !expandedCode
-                        ? "max-h-[300px] overflow-y-hidden"
-                        : "max-h-[800px] overflow-y-auto"
-                    }`}
-                  >
-                    <pre className="whitespace-pre-wrap break-all">
-                      <code className="text-gray-900 dark:text-white font-mono">
-                        {expandedCode
-                          ? contractInfo.sourceCode
-                          : getCodePreview(contractInfo.sourceCode!, 15)}
-                      </code>
-                    </pre>
-                  </div>
-
-                  {/* Gradient overlay for collapsed view */}
-                  {!expandedCode && contractInfo.sourceCode!.split("\n").length > 15 && (
-                    <div className="absolute bottom-0 left-0 right-0 h-20 bg-gradient-to-t from-gray-50 dark:from-gray-900 to-transparent pointer-events-none"></div>
-                  )}
-
-                  {/* Show more/less button */}
-                  {contractInfo.sourceCode!.split("\n").length > 15 && (
-                    <button
-                      onClick={() => setExpandedCode(!expandedCode)}
-                      className="mt-2 w-full flex items-center justify-center px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 
-                        bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 
-                        rounded-md transition-colors"
-                    >
-                      {expandedCode ? (
-                        <>
-                          <ChevronUp className="w-4 h-4 mr-2" />
-                          Show Less
-                        </>
-                      ) : (
-                        <>
-                          <ChevronDown className="w-4 h-4 mr-2" />
-                          Show More ({contractInfo.sourceCode!.split("\n").length - 15} more lines)
-                        </>
-                      )}
-                    </button>
-                  )}
-
-                  {/* Contract metadata */}
-                  <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-sm">
-                    <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
-                      <h4 className="font-medium text-gray-700 dark:text-gray-300">License</h4>
-                      <p className="mt-1 text-gray-600 dark:text-gray-400">
-                        {contractInfo.license}
-                      </p>
-                    </div>
-                    <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
-                      <h4 className="font-medium text-gray-700 dark:text-gray-300">Compiler</h4>
-                      <p className="mt-1 text-gray-600 dark:text-gray-400">
-                        {contractInfo.compiler}
-                      </p>
-                    </div>
-                    <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
-                      <h4 className="font-medium text-gray-700 dark:text-gray-300">Verification</h4>
-                      <p className="mt-1 text-gray-600 dark:text-gray-400 flex items-center">
-                        {contractInfo.verified ? (
-                          <>
-                            <Check className="w-4 h-4 text-green-500 mr-1" />
-                            Verified
-                          </>
-                        ) : (
-                          <>
-                            <X className="w-4 h-4 text-red-500 mr-1" />
-                            Unverified
-                          </>
-                        )}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-        </>
+      {/* Footer */}
+      {hasResults && !loading && (
+        <div className="border-t border-gray-100 px-4 py-2.5 dark:border-gray-800">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {passedCount} check{passedCount !== 1 ? "s" : ""} passed
+          </p>
+        </div>
       )}
     </div>
   );
-};
+}
+
+export default SmartContractScanner;

--- a/registry/w3-kit/smart-contract-scanner/smart-contract-scanner.tsx
+++ b/registry/w3-kit/smart-contract-scanner/smart-contract-scanner.tsx
@@ -1,657 +1,173 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import { useState } from "react";
 import {
-  Search,
   Shield,
-  AlertTriangle,
-  Check,
-  X,
-  ExternalLink,
-  Copy,
-  ChevronDown,
-  ChevronUp,
+  ShieldCheck,
+  ShieldAlert,
+  ShieldX,
+  Search,
+  Loader2,
 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ContractError, ContractInfo, SmartContractScannerProps } from "./types";
-import { isValidAddress, getStatusColor, getCodePreview, copyToClipboard } from "./utils";
+import { cn } from "@/lib/utils";
+import { SmartContractScannerProps, SecurityCheck } from "./types";
+import { truncateAddress } from "./utils";
 
-const mockContractData: Omit<ContractInfo, "address"> = {
-  name: "Example Token",
-  network: "Ethereum Mainnet",
-  verified: true,
-  license: "MIT",
-  compiler: "v0.8.17+commit.8df45f5f",
-  securityScore: 85,
-  checks: [
-    {
-      id: "1",
-      name: "Reentrancy Guard",
-      status: "safe",
-      description: "Contract is protected against reentrancy attacks",
-    },
-    {
-      id: "2",
-      name: "Access Control",
-      status: "warning",
-      description: "Owner has significant privileges",
-    },
-  ],
-  functions: [
-    {
-      name: "balanceOf",
-      type: "read",
-      inputs: [{ name: "account", type: "address" }],
-      outputs: [{ type: "uint256" }],
-      stateMutability: "view",
-    },
-    {
-      name: "transfer",
-      type: "write",
-      inputs: [
-        { name: "to", type: "address" },
-        { name: "amount", type: "uint256" },
-      ],
-      outputs: [{ type: "bool" }],
-      stateMutability: "nonpayable",
-    },
-  ],
-  sourceCode: `// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.17;
+const statusIcon = {
+  safe: ShieldCheck,
+  warning: ShieldAlert,
+  danger: ShieldX,
+} as const;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+const statusColor = {
+  safe: "text-green-600 dark:text-green-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  danger: "text-red-600 dark:text-red-400",
+} as const;
 
-/**
- * @title Example Token
- * @dev A simple ERC20 token with additional security features
- */
-contract ExampleToken is ERC20, Ownable, ReentrancyGuard {
-    uint256 private _maxSupply;
-    mapping(address => bool) private _blacklisted;
+const statusBadge = {
+  safe: "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400",
+  warning: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+  danger: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
+} as const;
 
-    event AddressBlacklisted(address indexed account);
-    event AddressUnblacklisted(address indexed account);
+function scoreColor(score: number) {
+  if (score > 70) return "border-green-500 text-green-600 dark:text-green-400";
+  if (score > 40) return "border-amber-500 text-amber-600 dark:text-amber-400";
+  return "border-red-500 text-red-600 dark:text-red-400";
+}
 
-    constructor() ERC20("Example Token", "EXT") {
-        _maxSupply = 1000000000 * 10**decimals();
-        _mint(msg.sender, 100000000 * 10**decimals());
-    }
-
-    function mint(address to, uint256 amount) external onlyOwner {
-        require(totalSupply() + amount <= _maxSupply, "Exceeds max supply");
-        _mint(to, amount);
-    }
-
-    function blacklistAddress(address account) external onlyOwner {
-        _blacklisted[account] = true;
-        emit AddressBlacklisted(account);
-    }
-
-    function unblacklistAddress(address account) external onlyOwner {
-        _blacklisted[account] = false;
-        emit AddressUnblacklisted(account);
-    }
-
-    function isBlacklisted(address account) external view returns (bool) {
-        return _blacklisted[account];
-    }
-
-    function _beforeTokenTransfer(
-        address from,
-        address to,
-        uint256 amount
-    ) internal override nonReentrant {
-        require(!_blacklisted[from] && !_blacklisted[to], "Blacklisted address");
-        super._beforeTokenTransfer(from, to, amount);
-    }
-}`,
-};
-
-export const SmartContractScanner: React.FC<SmartContractScannerProps> = ({
-  className = "",
-  variant = "default",
+export function SmartContractScanner({
+  address,
+  score,
+  checks,
   onScan,
-  onError,
-}) => {
-  const [address, setAddress] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [contractInfo, setContractInfo] = useState<ContractInfo | null>(null);
-  const [activeTab, setActiveTab] = useState<"overview" | "functions" | "code">("overview");
-  const [error, setError] = useState<ContractError | null>(null);
-  const [validationError, setValidationError] = useState<string | null>(null);
-  const [expandedCode, setExpandedCode] = useState(false);
-  const [copySuccess, setCopySuccess] = useState(false);
-  const codePreviewRef = useRef<HTMLDivElement>(null);
+  loading = false,
+  className,
+}: SmartContractScannerProps) {
+  const [input, setInput] = useState("");
+  const hasResults = score !== undefined && checks !== undefined;
+  const passedCount = checks?.filter((c) => c.status === "safe").length ?? 0;
 
-  const handleAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setAddress(value);
-
-    setValidationError(null);
-    setError(null);
-
-    if (value && !isValidAddress(value)) {
-      setValidationError(
-        "Please enter a valid Ethereum address (0x followed by 40 hex characters)",
-      );
-    }
+  const handleScan = () => {
+    const value = input.trim();
+    if (value && onScan) onScan(value);
   };
-
-  const handleScan = async () => {
-    if (!address) return;
-
-    if (!isValidAddress(address)) {
-      const errorMsg = ContractError.INVALID_ADDRESS;
-      setError(errorMsg);
-      onError?.(errorMsg);
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-    setValidationError(null);
-
-    try {
-      await new Promise((resolve, reject) => {
-        const shouldFail = Math.random() < 0.2;
-
-        setTimeout(() => {
-          if (shouldFail) {
-            reject(new Error("SCAN_FAILED"));
-          } else {
-            resolve(true);
-          }
-        }, 1500);
-      });
-
-      onScan?.(address);
-
-      setContractInfo({
-        ...mockContractData,
-        address: address,
-      });
-    } catch (err) {
-      let errorType = ContractError.UNKNOWN;
-
-      if (err instanceof Error) {
-        switch (err.message) {
-          case "NOT_FOUND":
-            errorType = ContractError.NOT_FOUND;
-            break;
-          case "NOT_VERIFIED":
-            errorType = ContractError.NOT_VERIFIED;
-            break;
-          case "NETWORK_ERROR":
-            errorType = ContractError.NETWORK_ERROR;
-            break;
-          case "SCAN_FAILED":
-            errorType = ContractError.SCAN_FAILED;
-            break;
-          case "RATE_LIMIT":
-            errorType = ContractError.RATE_LIMIT;
-            break;
-          case "TIMEOUT":
-            errorType = ContractError.TIMEOUT;
-            break;
-        }
-      }
-
-      setError(errorType);
-      onError?.(errorType);
-      setContractInfo(null);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleCopyToClipboard = (text: string) => {
-    copyToClipboard(text)
-      .then(() => {
-        setCopySuccess(true);
-        setTimeout(() => setCopySuccess(false), 2000);
-      })
-      .catch((err) => {
-        console.error("Failed to copy: ", err);
-      });
-  };
-
-  if (variant === "compact") {
-    return (
-      <Card className={className}>
-        <CardContent className="pt-6 space-y-4">
-          <div className="relative">
-            <Input
-              type="text"
-              value={address}
-              onChange={handleAddressChange}
-              placeholder="Enter contract address"
-              className={`pl-10 ${validationError ? "border-destructive" : ""}`}
-              disabled={isLoading}
-            />
-            <Search className="absolute left-3 top-2.5 w-4 h-4 text-muted-foreground" />
-          </div>
-
-          {validationError && <p className="text-sm text-destructive">{validationError}</p>}
-
-          <Button
-            onClick={handleScan}
-            disabled={!address || isLoading || !!validationError}
-            className="w-full"
-          >
-            {isLoading ? (
-              <div className="flex items-center justify-center space-x-2">
-                <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
-                <span>Scanning...</span>
-              </div>
-            ) : (
-              "Scan Contract"
-            )}
-          </Button>
-
-          {error && (
-            <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start space-x-2">
-              <AlertTriangle className="w-4 h-4 text-destructive flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-destructive">{error}</p>
-            </div>
-          )}
-
-          {contractInfo && (
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium">Security Score</span>
-                <span
-                  className={`text-sm font-medium ${
-                    contractInfo.securityScore >= 80
-                      ? "text-green-500"
-                      : contractInfo.securityScore >= 60
-                        ? "text-yellow-500"
-                        : "text-red-500"
-                  }`}
-                >
-                  {contractInfo.securityScore}/100
-                </span>
-              </div>
-
-              <div className="text-sm text-muted-foreground">
-                {contractInfo.checks.length} security checks completed
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    );
-  }
 
   return (
-    <Card className={className}>
-      <CardHeader>
-        <CardTitle>Smart Contract Scanner</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="space-y-4">
-          <div className="relative">
-            <Input
-              type="text"
-              value={address}
-              onChange={handleAddressChange}
-              placeholder="Enter contract address"
-              className={`pl-11 ${validationError ? "border-destructive" : ""}`}
-              disabled={isLoading}
-            />
-            <Search className="absolute left-3 top-3 w-5 h-5 text-muted-foreground" />
-          </div>
-
-          {validationError && <p className="text-sm text-destructive">{validationError}</p>}
-
-          <Button
-            onClick={handleScan}
-            disabled={!address || isLoading || !!validationError}
-            className="w-full"
-            size="lg"
-          >
-            {isLoading ? (
-              <div className="flex items-center justify-center space-x-2">
-                <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />
-                <span>Scanning Contract...</span>
-              </div>
-            ) : (
-              "Scan Contract"
-            )}
-          </Button>
-
-          {error && (
-            <div className="p-4 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start space-x-3">
-              <AlertTriangle className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
-              <div className="flex-1">
-                <h4 className="text-sm font-medium text-destructive">Error</h4>
-                <p className="mt-1 text-sm text-destructive/90">{error}</p>
-              </div>
-            </div>
-          )}
-        </div>
-      </CardContent>
-
-      {contractInfo && (
-        <>
-          <div className="border-b">
-            <div className="flex space-x-4 px-6 overflow-x-auto">
-              {(["overview", "functions", "code"] as const).map((tab) => (
-                <Button
-                  key={tab}
-                  onClick={() => setActiveTab(tab)}
-                  variant="ghost"
-                  className={`px-4 py-3 rounded-none border-b-2 transition-colors whitespace-nowrap ${
-                    activeTab === tab
-                      ? "border-primary text-primary"
-                      : "border-transparent hover:text-foreground"
-                  }`}
-                >
-                  {tab.charAt(0).toUpperCase() + tab.slice(1)}
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          <CardContent className="space-y-6">
-            {activeTab === "overview" && (
-              <div className="space-y-6">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-sm font-medium text-muted-foreground">Contract Name</h3>
-                      <p className="mt-1 text-sm">{contractInfo.name}</p>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-muted-foreground">
-                        Contract Address
-                      </h3>
-                      <div className="mt-1 flex items-center">
-                        <p className="text-sm truncate max-w-[180px] sm:max-w-xs">
-                          {contractInfo.address}
-                        </p>
-                        <Button
-                          onClick={() => handleCopyToClipboard(contractInfo.address)}
-                          variant="ghost"
-                          size="icon"
-                          className="ml-2 h-6 w-6"
-                          title="Copy address"
-                        >
-                          <Copy className="w-4 h-4" />
-                        </Button>
-                      </div>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-muted-foreground">Network</h3>
-                      <p className="mt-1 text-sm">{contractInfo.network}</p>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-muted-foreground">
-                        Compiler Version
-                      </h3>
-                      <p className="mt-1 text-sm">{contractInfo.compiler}</p>
-                    </div>
-                  </div>
-
-                  <div className="space-y-4">
-                    <div>
-                      <h3 className="text-sm font-medium text-muted-foreground">Security Score</h3>
-                      <div className="mt-1 flex items-center">
-                        <span
-                          className={`text-2xl font-bold ${
-                            contractInfo.securityScore >= 80
-                              ? "text-green-500"
-                              : contractInfo.securityScore >= 60
-                                ? "text-yellow-500"
-                                : "text-red-500"
-                          }`}
-                        >
-                          {contractInfo.securityScore}
-                        </span>
-                        <span className="text-sm text-muted-foreground ml-1">/100</span>
-                      </div>
-                    </div>
-                    <div>
-                      <h3 className="text-sm font-medium text-muted-foreground">
-                        Verification Status
-                      </h3>
-                      <div className="mt-1 flex items-center">
-                        {contractInfo.verified ? (
-                          <Check className="w-4 h-4 text-green-500" />
-                        ) : (
-                          <X className="w-4 h-4 text-red-500" />
-                        )}
-                        <span className="ml-2 text-sm">
-                          {contractInfo.verified ? "Verified" : "Unverified"}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="space-y-4">
-                  <h3 className="text-sm font-medium">Security Checks</h3>
-                  <div className="space-y-3">
-                    {contractInfo.checks.map((check) => (
-                      <div key={check.id} className="p-4 border rounded-lg">
-                        <div className="flex items-start justify-between">
-                          <div className="space-y-1">
-                            <div className="flex items-center space-x-2">
-                              {check.status === "safe" && (
-                                <Shield className={`w-4 h-4 ${getStatusColor(check.status)}`} />
-                              )}
-                              {check.status === "warning" && (
-                                <AlertTriangle
-                                  className={`w-4 h-4 ${getStatusColor(check.status)}`}
-                                />
-                              )}
-                              {check.status === "danger" && (
-                                <AlertTriangle
-                                  className={`w-4 h-4 ${getStatusColor(check.status)}`}
-                                />
-                              )}
-                              <span className="font-medium">{check.name}</span>
-                            </div>
-                            <p className="text-sm text-muted-foreground">{check.description}</p>
-                          </div>
-                          <span className={`text-sm font-medium ${getStatusColor(check.status)}`}>
-                            {check.status.toUpperCase()}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {activeTab === "functions" && (
-              <div className="space-y-4">
-                {contractInfo.functions.map((func, index) => (
-                  <div key={`${func.name}-${index}`} className="p-4 border rounded-lg">
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center space-x-2">
-                        <span
-                          className={`px-2 py-1 text-xs font-medium rounded-full ${
-                            func.type === "read"
-                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                              : "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400"
-                          }`}
-                        >
-                          {func.type.toUpperCase()}
-                        </span>
-                        <span className="font-medium">{func.name}</span>
-                      </div>
-                      <span className="text-sm text-muted-foreground">{func.stateMutability}</span>
-                    </div>
-
-                    <div className="space-y-2">
-                      {func.inputs.length > 0 && (
-                        <div>
-                          <span className="text-sm text-muted-foreground">Inputs:</span>
-                          <div className="mt-1 space-y-1">
-                            {func.inputs.map((input, i) => (
-                              <div key={`${input.name}-${i}`} className="text-sm">
-                                {input.name}: {input.type}
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      <div>
-                        <span className="text-sm text-muted-foreground">Returns:</span>
-                        <div className="mt-1 text-sm">
-                          {func.outputs.map((output) => output.type).join(", ")}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {activeTab === "code" && contractInfo.sourceCode && (
-              <div className="space-y-4">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between pb-4 border-b border-gray-200 dark:border-gray-700">
-                  <div className="mb-2 sm:mb-0">
-                    <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400">
-                      Contract Address
-                    </h3>
-                    <div className="mt-1 flex items-center">
-                      <p className="text-sm text-gray-900 dark:text-white truncate max-w-[200px] sm:max-w-xs md:max-w-md">
-                        {contractInfo.address}
-                      </p>
-                      <button
-                        onClick={() => handleCopyToClipboard(contractInfo.address)}
-                        className="ml-2 p-1 text-gray-500 hover:text-gray-700 dark:text-gray-400
-                          dark:hover:text-gray-200 transition-colors"
-                        title="Copy address"
-                      >
-                        <Copy className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </div>
-                  <div className="flex space-x-2">
-                    <button
-                      onClick={() => handleCopyToClipboard(contractInfo.sourceCode!)}
-                      className={`px-3 py-1.5 text-xs font-medium ${
-                        copySuccess
-                          ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                          : "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700"
-                      } rounded-md transition-colors flex items-center`}
-                      title="Copy source code"
-                    >
-                      {copySuccess ? (
-                        <>
-                          <Check className="w-3.5 h-3.5 mr-1.5" />
-                          Copied!
-                        </>
-                      ) : (
-                        <>
-                          <Copy className="w-3.5 h-3.5 mr-1.5" />
-                          Copy Code
-                        </>
-                      )}
-                    </button>
-                    <a
-                      href={`https://etherscan.io/address/${contractInfo.address}#code`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="px-3 py-1.5 text-xs font-medium text-gray-700 dark:text-gray-300
-                        bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700
-                        rounded-md transition-colors flex items-center"
-                    >
-                      <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
-                      View on Etherscan
-                    </a>
-                  </div>
-                </div>
-
-                <div className="relative">
-                  <div
-                    ref={codePreviewRef}
-                    className={`p-4 bg-gray-50 dark:bg-gray-900 rounded-lg overflow-x-auto text-sm ${
-                      !expandedCode
-                        ? "max-h-[300px] overflow-y-hidden"
-                        : "max-h-[800px] overflow-y-auto"
-                    }`}
-                  >
-                    <pre className="whitespace-pre-wrap break-all">
-                      <code className="text-gray-900 dark:text-white font-mono">
-                        {expandedCode
-                          ? contractInfo.sourceCode
-                          : getCodePreview(contractInfo.sourceCode!, 15)}
-                      </code>
-                    </pre>
-                  </div>
-
-                  {!expandedCode && contractInfo.sourceCode!.split("\n").length > 15 && (
-                    <div className="absolute bottom-0 left-0 right-0 h-20 bg-gradient-to-t from-gray-50 dark:from-gray-900 to-transparent pointer-events-none"></div>
-                  )}
-
-                  {contractInfo.sourceCode!.split("\n").length > 15 && (
-                    <button
-                      onClick={() => setExpandedCode(!expandedCode)}
-                      className="mt-2 w-full flex items-center justify-center px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300
-                        bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700
-                        rounded-md transition-colors"
-                    >
-                      {expandedCode ? (
-                        <>
-                          <ChevronUp className="w-4 h-4 mr-2" />
-                          Show Less
-                        </>
-                      ) : (
-                        <>
-                          <ChevronDown className="w-4 h-4 mr-2" />
-                          Show More ({contractInfo.sourceCode!.split("\n").length - 15} more lines)
-                        </>
-                      )}
-                    </button>
-                  )}
-
-                  <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 text-sm">
-                    <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
-                      <h4 className="font-medium text-gray-700 dark:text-gray-300">License</h4>
-                      <p className="mt-1 text-gray-600 dark:text-gray-400">
-                        {contractInfo.license}
-                      </p>
-                    </div>
-                    <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
-                      <h4 className="font-medium text-gray-700 dark:text-gray-300">Compiler</h4>
-                      <p className="mt-1 text-gray-600 dark:text-gray-400">
-                        {contractInfo.compiler}
-                      </p>
-                    </div>
-                    <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
-                      <h4 className="font-medium text-gray-700 dark:text-gray-300">Verification</h4>
-                      <p className="mt-1 text-gray-600 dark:text-gray-400 flex items-center">
-                        {contractInfo.verified ? (
-                          <>
-                            <Check className="w-4 h-4 text-green-500 mr-1" />
-                            Verified
-                          </>
-                        ) : (
-                          <>
-                            <X className="w-4 h-4 text-red-500 mr-1" />
-                            Unverified
-                          </>
-                        )}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </>
+    <div
+      className={cn(
+        "max-w-sm rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        className,
       )}
-    </Card>
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 pt-4 pb-3">
+        <Shield className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        <span className="text-sm font-medium text-gray-900 dark:text-white">
+          Scanner
+        </span>
+        {address && (
+          <span className="ml-auto rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {truncateAddress(address)}
+          </span>
+        )}
+      </div>
+
+      <div className="px-4 pb-4 space-y-4">
+        {/* Input state — no results yet */}
+        {!hasResults && !loading && (
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleScan()}
+              placeholder="0x..."
+              className="flex-1 rounded-lg border border-gray-200 bg-transparent px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
+            />
+            <button
+              onClick={handleScan}
+              disabled={!input.trim()}
+              className="rounded-lg bg-gray-900 px-3 py-2 text-white transition-colors hover:bg-gray-800 disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+            >
+              <Search className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Loading state */}
+        {loading && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+          </div>
+        )}
+
+        {/* Results */}
+        {hasResults && !loading && (
+          <>
+            {/* Score circle */}
+            <div className="flex justify-center py-2">
+              <div
+                className={cn(
+                  "flex h-20 w-20 items-center justify-center rounded-full border-4",
+                  scoreColor(score),
+                )}
+              >
+                <span className="text-2xl font-bold tabular-nums">{score}</span>
+              </div>
+            </div>
+
+            {/* Check list */}
+            <ul className="space-y-1.5">
+              {checks.map((check: SecurityCheck) => {
+                const Icon = statusIcon[check.status];
+                return (
+                  <li
+                    key={check.name}
+                    className="flex items-start gap-2.5 rounded-lg px-2 py-2"
+                  >
+                    <Icon
+                      className={cn("mt-0.5 h-4 w-4 shrink-0", statusColor[check.status])}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-gray-900 dark:text-white">
+                          {check.name}
+                        </span>
+                        <span
+                          className={cn(
+                            "rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none",
+                            statusBadge[check.status],
+                          )}
+                        >
+                          {check.status}
+                        </span>
+                      </div>
+                      {check.description && (
+                        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                          {check.description}
+                        </p>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+      </div>
+
+      {/* Footer */}
+      {hasResults && !loading && (
+        <div className="border-t border-gray-100 px-4 py-2.5 dark:border-gray-800">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {passedCount} check{passedCount !== 1 ? "s" : ""} passed
+          </p>
+        </div>
+      )}
+    </div>
   );
-};
+}
 
 export default SmartContractScanner;

--- a/registry/w3-kit/smart-contract-scanner/types.ts
+++ b/registry/w3-kit/smart-contract-scanner/types.ts
@@ -1,46 +1,16 @@
-export enum ContractError {
-  INVALID_ADDRESS = "Invalid contract address format",
-  NOT_FOUND = "Contract not found",
-  NOT_VERIFIED = "Contract is not verified",
-  NETWORK_ERROR = "Network connection error",
-  SCAN_FAILED = "Contract scanning failed",
-  RATE_LIMIT = "API rate limit exceeded",
-  TIMEOUT = "Request timeout",
-  UNKNOWN = "An unknown error occurred",
-}
+export type CheckStatus = "safe" | "warning" | "danger";
 
 export interface SecurityCheck {
-  id: string;
   name: string;
-  status: "safe" | "warning" | "danger";
-  description: string;
-  details?: string;
-}
-
-export interface ContractFunction {
-  name: string;
-  type: "read" | "write";
-  inputs: { name: string; type: string }[];
-  outputs: { type: string }[];
-  stateMutability: string;
-}
-
-export interface ContractInfo {
-  name: string;
-  address: string;
-  network: string;
-  verified: boolean;
-  license: string;
-  compiler: string;
-  securityScore: number;
-  checks: SecurityCheck[];
-  functions: ContractFunction[];
-  sourceCode?: string;
+  status: CheckStatus;
+  description?: string;
 }
 
 export interface SmartContractScannerProps {
-  className?: string;
-  variant?: "default" | "compact";
+  address?: string;
+  score?: number;
+  checks?: SecurityCheck[];
   onScan?: (address: string) => void;
-  onError?: (error: ContractError) => void;
+  loading?: boolean;
+  className?: string;
 }

--- a/registry/w3-kit/smart-contract-scanner/utils.ts
+++ b/registry/w3-kit/smart-contract-scanner/utils.ts
@@ -1,29 +1,4 @@
-import { SecurityCheck } from "./types";
-
-export function isValidAddress(address: string): boolean {
-  return /^0x[a-fA-F0-9]{40}$/.test(address);
-}
-
-export function getStatusColor(status: SecurityCheck["status"]): string {
-  switch (status) {
-    case "safe":
-      return "text-green-500 dark:text-green-400";
-    case "warning":
-      return "text-yellow-500 dark:text-yellow-400";
-    case "danger":
-      return "text-red-500 dark:text-red-400";
-    default:
-      return "text-gray-500 dark:text-gray-400";
-  }
-}
-
-export function getCodePreview(sourceCode: string, maxLines = 15): string {
-  const lines = sourceCode.split("\n");
-  if (lines.length <= maxLines) return sourceCode;
-
-  return lines.slice(0, maxLines).join("\n") + "\n...";
-}
-
-export function copyToClipboard(text: string): Promise<void> {
-  return navigator.clipboard.writeText(text);
+export function truncateAddress(address: string): string {
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 }


### PR DESCRIPTION
## Summary
- Rewrote SmartContractScanner as a pure, controlled UI component — parent provides `address`, `score`, `checks`, `loading` via props instead of the component generating fake mock data internally
- Simplified types: `CheckStatus`, `SecurityCheck`, `SmartContractScannerProps` — removed `ContractError`, `ContractInfo`, `ContractFunction` and all bloated internals
- Utility reduced to a single `truncateAddress` helper — removed `getMockChecks`, `isValidAddress`, `getStatusColor`, `getCodePreview`, `copyToClipboard`
- Matches design system: `cn` from `@/lib/utils`, lucide icons (Shield, ShieldCheck, ShieldAlert, ShieldX, Search, Loader2), card with `rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950`, `max-w-sm`
- Updated all three copies: `registry/`, `components/`, `packages/create-w3-kit/`

## Test plan
- [ ] Render with no props — should show address input + scan button
- [ ] Pass `loading={true}` — should show centered spinner
- [ ] Pass `address`, `score`, and `checks` — should show score circle with colored border (green >70, yellow >40, red <=40), check list with status icons/badges, and footer with passed count
- [ ] Verify dark mode styling
- [ ] Confirm `onScan` callback fires with entered address