### PR TITLE
fix: unblock ui CI (tsconfig + eslint + cause chaining)

### DIFF
--- a/components/network-switcher/utils.ts
+++ b/components/network-switcher/utils.ts
@@ -37,13 +37,10 @@ export async function switchNetwork(network: Network): Promise<void> {
             },
           ],
         });
-      } catch (
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        addError: unknown
-      ) {
-        throw new Error("Failed to add network");
+      } catch (addError: unknown) {
+        throw new Error("Failed to add network", { cause: addError });
       }
     }
-    throw new Error("Failed to switch network");
+    throw new Error("Failed to switch network", { cause: switchError });
   }
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,8 @@
-export default (await import("@w3-kit/config/eslint")).default;
+const base = (await import("@w3-kit/config/eslint")).default;
+
+export default [
+  ...base,
+  {
+    ignores: ["**/dist/**", "packages/create-w3-kit/**"],
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "packages/mcp-server"]
+  "exclude": ["node_modules", "packages/create-w3-kit", "packages/mcp-server"]
 }


### PR DESCRIPTION
## Summary

ui main CI has been failing since `@w3-kit/config@0.1.1` (and 0.2.0) landed because:

1. **tsconfig includes `packages/create-w3-kit/index.ts`** but root has no `chalk`/`commander` deps, causing TS2307 errors during typecheck
2. **`@eslint/js@10` added the `preserve-caught-error` rule**, which flags pre-existing un-chained throws in `network-switcher/utils.ts`

This was previously masked because the older config pinned narrower deps. Recent dependabot PRs (#118 lucide, #124 tailwind-merge) triggered the same regression on main.

## Changes

- `tsconfig.json`: add `packages/create-w3-kit` to `exclude`. The subpackage has its own `tsconfig.json` that the `build` script already targets (`tsc -p packages/create-w3-kit`). Root typecheck should not pull it in.
- `eslint.config.js`: ignore `packages/create-w3-kit/**` to match the tsconfig boundary. Also keeps the existing `**/dist/**` ignore.
- `components/network-switcher/utils.ts`: chain catch cause via `new Error(msg, { cause: err })` for two throws. Removed an outdated `eslint-disable-next-line @typescript-eslint/no-unused-vars` comment that became inaccurate once the variable was used.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` 0 errors (2 pre-existing warnings remain, not blockers)
- [x] `npm run format:check` passes
- [x] `npm run build` succeeds