### PR TITLE
feat: registry component polish across 22 components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
         "@types/react-dom": "^18.0.0",
         "@w3-kit/config": "^0.1.0",
         "autoprefixer": "^10.5.0",
+        "chalk": "^5.3.0",
+        "commander": "^11.1.0",
         "eslint": "^10.4.0",
         "postcss": "^8.5.15",
         "prettier": "^3.8.3",
@@ -53,6 +55,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -332,6 +335,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -342,6 +346,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -351,12 +356,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -373,6 +380,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -386,6 +394,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -395,6 +404,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1311,14 +1321,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1329,7 +1339,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -1652,12 +1662,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1671,6 +1683,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1683,6 +1696,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/aria-hidden": {
@@ -1804,6 +1818,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1829,6 +1844,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1925,6 +1941,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -1951,6 +1968,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -1967,6 +1997,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -1991,6 +2022,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2041,12 +2073,13 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=16"
       }
     },
     "node_modules/cross-spawn": {
@@ -2075,6 +2108,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -2087,7 +2121,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2194,12 +2228,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -2245,6 +2281,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2470,6 +2507,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2486,6 +2524,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2512,6 +2551,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -2521,6 +2561,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2551,6 +2592,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2631,6 +2673,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2645,6 +2688,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2712,6 +2756,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -2815,6 +2860,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2923,6 +2969,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -2965,6 +3012,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -2997,6 +3045,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3006,6 +3055,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3031,6 +3081,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -3184,6 +3235,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -3244,6 +3296,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -3256,6 +3309,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3319,6 +3373,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3328,6 +3383,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -3341,6 +3397,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3386,6 +3443,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -3397,6 +3455,7 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3432,6 +3491,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3441,6 +3501,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3450,6 +3511,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3590,18 +3652,21 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3614,6 +3679,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3623,6 +3689,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3642,6 +3709,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3670,6 +3738,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -3687,6 +3756,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3712,6 +3782,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3754,6 +3825,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3779,6 +3851,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3792,6 +3865,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -3862,6 +3936,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3993,6 +4068,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -4002,6 +4078,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -4014,6 +4091,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4061,6 +4139,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4082,6 +4161,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -4092,6 +4172,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4288,6 +4369,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4324,6 +4406,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -4340,6 +4423,16 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/supports-color": {
@@ -4359,6 +4452,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4381,6 +4475,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -4427,6 +4522,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -4436,6 +4532,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -4448,6 +4545,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4464,6 +4562,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -4489,6 +4588,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -4643,6 +4743,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "postcss": "^8.5.15",
     "prettier": "^3.8.3",
     "tailwindcss": "^3.4.17",
-    "typescript": "^4.9.0"
+    "typescript": "^4.9.0",
+    "chalk": "^5.3.0",
+    "commander": "^11.1.0"
   },
   "bin": {
     "w3-kit": "./packages/create-w3-kit/dist/index.js"

--- a/registry/w3-kit/address-book/address-book.tsx
+++ b/registry/w3-kit/address-book/address-book.tsx
@@ -181,7 +181,10 @@ export function AddressBook({
                   {entry.name}
                 </span>
                 {entry.ensName && (
-                  <span className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                  <span
+                    className="rounded-md bg-blue-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-600 dark:bg-blue-500/10 dark:text-blue-400"
+                    title="ENS name resolved"
+                  >
                     ENS
                   </span>
                 )}

--- a/registry/w3-kit/asset-portfolio/asset-portfolio.tsx
+++ b/registry/w3-kit/asset-portfolio/asset-portfolio.tsx
@@ -139,9 +139,10 @@ export function AssetPortfolio({
       </ul>
 
       {/* Footer */}
-      <div className="border-t border-gray-200 px-4 py-2.5 dark:border-gray-800">
+      <div className="border-t border-gray-200 px-4 py-2.5 text-center dark:border-gray-800">
         <p className="text-xs text-gray-500 dark:text-gray-400">
           {sorted.length} asset{sorted.length !== 1 ? "s" : ""}
+          {totalValue > 0 && <> &middot; {formatCurrency(totalValue)}</>}
         </p>
       </div>
     </div>

--- a/registry/w3-kit/contract-interaction/contract-interaction.tsx
+++ b/registry/w3-kit/contract-interaction/contract-interaction.tsx
@@ -1,23 +1,26 @@
 "use client";
 
 import React, { useState } from "react";
-import { Code, Loader2, Play } from "lucide-react";
+import { Code, Loader2, Play, Wallet } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ContractInteractionProps, ContractFunction } from "./types";
 import { truncateAddress } from "./utils";
 
 export function ContractInteraction({
   address,
+  standard,
   functions,
   onExecute,
   executingFn,
+  results,
   className,
 }: ContractInteractionProps) {
   const [tab, setTab] = useState<"read" | "write">("read");
   const [inputValues, setInputValues] = useState<Record<string, string[]>>({});
-  const [results] = useState<Record<string, string>>({});
 
   const filtered = functions.filter((fn) => fn.type === tab);
+  const readCount = functions.filter((f) => f.type === "read").length;
+  const writeCount = functions.filter((f) => f.type === "write").length;
 
   function getValues(fn: ContractFunction) {
     return inputValues[fn.name] ?? fn.inputs.map(() => "");
@@ -41,6 +44,11 @@ export function ContractInteraction({
       <div className="flex items-center gap-3 px-5 py-4">
         <Code className="h-5 w-5 text-gray-500 dark:text-gray-400" />
         <h3 className="text-base font-semibold text-gray-900 dark:text-white">Contract</h3>
+        {standard && (
+          <span className="rounded-md bg-gray-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+            {standard}
+          </span>
+        )}
         {address && (
           <span className="ml-auto rounded-full bg-gray-100 px-2.5 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
             {truncateAddress(address)}
@@ -77,24 +85,61 @@ export function ContractInteraction({
         {filtered.map((fn) => {
           const values = getValues(fn);
           const isExecuting = executingFn === fn.name;
-          const result = results[fn.name];
+          const result = results?.[fn.name];
 
           return (
             <div key={fn.name} className="rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-gray-900">
-              <p className="text-sm font-medium text-gray-900 dark:text-white">{fn.name}</p>
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="text-sm font-medium text-gray-900 dark:text-white">{fn.name}</p>
+                {fn.outputs && fn.outputs.length > 0 && (
+                  <span className="font-mono text-[10px] text-gray-500 dark:text-gray-400">
+                    → {fn.outputs.join(", ")}
+                  </span>
+                )}
+              </div>
+              {fn.description && (
+                <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{fn.description}</p>
+              )}
 
               {fn.inputs.length > 0 && (
-                <div className="mt-2 space-y-1.5">
-                  {fn.inputs.map((label, idx) => (
-                    <input
-                      key={idx}
-                      type="text"
-                      placeholder={label}
-                      value={values[idx] ?? ""}
-                      onChange={(e) => setFieldValue(fn, idx, e.target.value)}
-                      className="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-gray-600"
-                    />
-                  ))}
+                <div className="mt-2 space-y-2">
+                  {fn.inputs.map((label, idx) => {
+                    const detail = fn.inputDetails?.[idx];
+                    const inputLabel = detail?.label ?? label;
+                    const placeholder = detail?.placeholder ?? label;
+                    return (
+                      <div key={idx}>
+                        {(detail?.label || detail?.helper) && (
+                          <div className="mb-1 flex items-center justify-between">
+                            {detail?.label && (
+                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                                {inputLabel}
+                              </span>
+                            )}
+                            {detail?.helper && (
+                              <span className="text-[11px] text-gray-500 dark:text-gray-400">
+                                {detail.helper}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                        <input
+                          type="text"
+                          placeholder={placeholder}
+                          value={values[idx] ?? ""}
+                          onChange={(e) => setFieldValue(fn, idx, e.target.value)}
+                          className="w-full rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-gray-600"
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+
+              {fn.type === "write" && (
+                <div className="mt-2 flex items-center gap-1.5 rounded-md bg-amber-100/60 px-2 py-1 text-[11px] text-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+                  <Wallet className="h-3 w-3" />
+                  Requires wallet signature
                 </div>
               )}
 
@@ -114,7 +159,7 @@ export function ContractInteraction({
                 ) : (
                   <Play className="h-3.5 w-3.5" />
                 )}
-                {isExecuting ? "Executing..." : "Execute"}
+                {isExecuting ? "Executing..." : fn.type === "read" ? "Query" : "Execute"}
               </button>
 
               {result && (
@@ -125,6 +170,16 @@ export function ContractInteraction({
             </div>
           );
         })}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between border-t border-gray-200 px-4 py-2.5 dark:border-gray-800">
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {functions.length} function{functions.length !== 1 ? "s" : ""}
+        </span>
+        <span className="text-[11px] text-gray-400 dark:text-gray-500">
+          {readCount} read · {writeCount} write
+        </span>
       </div>
     </div>
   );

--- a/registry/w3-kit/contract-interaction/types.ts
+++ b/registry/w3-kit/contract-interaction/types.ts
@@ -1,13 +1,29 @@
+export interface ContractFunctionInput {
+  label?: string;
+  placeholder?: string;
+  helper?: string;
+}
+
 export interface ContractFunction {
   name: string;
   type: "read" | "write";
+  /** Simple placeholder/label strings, one per input. */
   inputs: string[];
+  /** Rich per-input metadata, indexed by position. Falls back to `inputs` when omitted. */
+  inputDetails?: ContractFunctionInput[];
+  description?: string;
+  /** Declared output types, e.g. `["uint256"]`. */
+  outputs?: string[];
 }
 
 export interface ContractInteractionProps {
   address?: string;
+  /** Token/contract standard shown as a small badge in the header (e.g. `"ERC-20"`). */
+  standard?: string;
   functions: ContractFunction[];
   onExecute?: (fn: ContractFunction, values: string[]) => void;
   executingFn?: string;
+  /** Map of function name to last execution result text. */
+  results?: Record<string, string>;
   className?: string;
 }

--- a/registry/w3-kit/ens-resolver/ens-resolver.tsx
+++ b/registry/w3-kit/ens-resolver/ens-resolver.tsx
@@ -1,27 +1,36 @@
 "use client";
 
 import React, { useState } from "react";
-import { AtSign, Copy, Check, Loader2, Search } from "lucide-react";
+import { ArrowDownUp, AtSign, Copy, Check, ExternalLink, Loader2, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ENSResolverProps, ENSResult } from "./types";
 import { truncateAddress } from "./utils";
 
-export function ENSResolver({ onResolve, resolver, className }: ENSResolverProps) {
+export function ENSResolver({
+  onResolve,
+  resolver,
+  suggestions,
+  explorerUrl = "https://etherscan.io/address/",
+  idleCaption = "Enter a name or address",
+  className,
+}: ENSResolverProps) {
   const [input, setInput] = useState("");
   const [result, setResult] = useState<ENSResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState<string | null>(null);
 
-  async function handleResolve() {
-    if (!input.trim() || !resolver) return;
+  async function handleResolve(query?: string) {
+    const value = (query ?? input).trim();
+    if (!value || !resolver) return;
 
+    setInput(value);
     setIsLoading(true);
     setError(null);
     setResult(null);
 
     try {
-      const res = await resolver(input.trim());
+      const res = await resolver(value);
       setResult(res);
       onResolve?.(res);
     } catch (err) {
@@ -32,62 +41,129 @@ export function ENSResolver({ onResolve, resolver, className }: ENSResolverProps
   }
 
   async function handleCopy(text: string, key: string) {
-    await navigator.clipboard.writeText(text);
+    await navigator.clipboard.writeText(text).catch(() => {});
     setCopied(key);
     setTimeout(() => setCopied(null), 2000);
   }
 
+  function handleReset() {
+    setInput("");
+    setResult(null);
+    setError(null);
+  }
+
+  const footerText = result
+    ? "Resolved on Ethereum"
+    : isLoading
+      ? "Looking up..."
+      : error
+        ? "Lookup failed"
+        : idleCaption;
+
   return (
     <div
       className={cn(
-        "w-full max-w-sm rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        "w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
         className,
       )}
     >
       {/* Header */}
-      <div className="flex items-center gap-3 px-5 py-4">
-        <AtSign className="h-5 w-5 text-gray-500 dark:text-gray-400" />
-        <h3 className="text-base font-semibold text-gray-900 dark:text-white">ENS</h3>
+      <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <div className="flex items-center gap-2.5">
+          <AtSign size={18} className="text-gray-900 dark:text-gray-100" />
+          <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">ENS Resolver</h3>
+        </div>
+        {result && (
+          <button
+            onClick={handleReset}
+            className="text-xs font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
+          >
+            New lookup
+          </button>
+        )}
       </div>
 
-      {/* Search */}
-      <div className="space-y-3 px-5 pb-5">
-        <div className="flex gap-2">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
-            <input
-              type="text"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleResolve()}
-              placeholder="vitalik.eth or 0x..."
-              className="w-full rounded-xl border border-gray-200 bg-gray-50 py-2.5 pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-gray-600"
-            />
-          </div>
-          <button
-            onClick={handleResolve}
-            disabled={isLoading || !input.trim()}
-            className={cn(
-              "flex shrink-0 items-center justify-center rounded-xl bg-gray-900 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200",
-              (isLoading || !input.trim()) && "cursor-not-allowed opacity-50",
-            )}
-          >
-            {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : "Resolve"}
-          </button>
-        </div>
-
-        {/* Error */}
-        {error && (
-          <p className="rounded-xl bg-red-50 px-3 py-2.5 text-sm text-red-600 dark:bg-red-950/30 dark:text-red-400">
-            {error}
+      {/* Search / idle */}
+      {!result && (
+        <div className="space-y-3 px-5 py-4">
+          <p className="text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            Lookup
           </p>
-        )}
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
+              <input
+                type="text"
+                value={input}
+                onChange={(e) => {
+                  setInput(e.target.value);
+                  if (error) setError(null);
+                }}
+                onKeyDown={(e) => e.key === "Enter" && handleResolve()}
+                placeholder="ENS name or 0x address"
+                className={cn(
+                  "w-full rounded-xl border bg-gray-50 py-2.5 pl-9 pr-3 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-500",
+                  error
+                    ? "border-red-300 focus:ring-red-300 dark:border-red-700 dark:focus:ring-red-800"
+                    : "border-gray-200 focus:ring-gray-300 dark:border-gray-700 dark:focus:ring-gray-600",
+                )}
+              />
+            </div>
+            <button
+              onClick={() => handleResolve()}
+              disabled={isLoading || !input.trim()}
+              className={cn(
+                "flex shrink-0 items-center justify-center gap-1.5 rounded-xl bg-gray-900 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200",
+                (isLoading || !input.trim()) && "cursor-not-allowed opacity-50",
+              )}
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <>
+                  <Search className="h-3.5 w-3.5" />
+                  Resolve
+                </>
+              )}
+            </button>
+          </div>
 
-        {/* Result card */}
-        {result && (
-          <div className="rounded-xl bg-gray-50 px-3 py-3 dark:bg-gray-900">
-            <div className="flex items-center gap-3">
-              {result.avatar && (
+          {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
+
+          {!input && !isLoading && suggestions && suggestions.length > 0 && (
+            <div>
+              <p className="mb-1.5 text-xs text-gray-500 dark:text-gray-400">Try:</p>
+              <div className="flex flex-wrap gap-1.5">
+                {suggestions.map((s) => (
+                  <button
+                    key={s}
+                    onClick={() => handleResolve(s)}
+                    className="rounded-lg border border-gray-200 px-2.5 py-1 font-mono text-xs text-gray-700 transition-colors hover:border-gray-300 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:border-gray-600 dark:hover:bg-gray-800"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && !result && (
+        <div className="flex flex-col items-center gap-3 px-5 pb-5">
+          <Loader2 className="h-6 w-6 animate-spin text-gray-400 dark:text-gray-500" />
+          <p className="font-mono text-xs text-gray-500 dark:text-gray-400">{input}</p>
+        </div>
+      )}
+
+      {/* Result */}
+      {result && (
+        <div className="space-y-2 px-5 py-4">
+          {/* ENS Name block */}
+          {result.ensName && (
+            <div className="flex items-center gap-3 rounded-xl bg-gray-100 px-3.5 py-3 dark:bg-gray-800/60">
+              {result.avatar ? (
                 <img
                   src={result.avatar}
                   alt="Avatar"
@@ -95,47 +171,88 @@ export function ENSResolver({ onResolve, resolver, className }: ENSResolverProps
                   height={40}
                   className="h-10 w-10 shrink-0 rounded-full bg-gray-200 object-cover dark:bg-gray-700"
                 />
+              ) : (
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white text-base font-semibold text-gray-700 dark:bg-gray-900 dark:text-gray-200">
+                  {result.ensName.charAt(0).toUpperCase()}
+                </div>
               )}
-              <div className="min-w-0 flex-1 space-y-1">
-                {result.ensName && (
-                  <div className="flex items-center gap-2">
-                    <p className="truncate text-sm font-medium text-gray-900 dark:text-white">
-                      {result.ensName}
-                    </p>
-                    <button
-                      onClick={() => handleCopy(result.ensName!, "ens")}
-                      className="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                    >
-                      {copied === "ens" ? (
-                        <Check className="h-3.5 w-3.5 text-green-500" />
-                      ) : (
-                        <Copy className="h-3.5 w-3.5" />
-                      )}
-                    </button>
-                  </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  ENS Name
+                </p>
+                <p className="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                  {result.ensName}
+                </p>
+              </div>
+              <button
+                onClick={() => handleCopy(result.ensName!, "ens")}
+                className="shrink-0 rounded-md p-1.5 text-gray-400 hover:bg-white hover:text-gray-700 dark:hover:bg-gray-900 dark:hover:text-gray-200"
+                title="Copy ENS name"
+              >
+                {copied === "ens" ? (
+                  <Check className="h-3.5 w-3.5 text-green-500" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
                 )}
-                {result.address && (
-                  <div className="flex items-center gap-2">
-                    <p className="truncate font-mono text-xs text-gray-500 dark:text-gray-400">
-                      {truncateAddress(result.address)}
-                    </p>
-                    <button
-                      onClick={() => handleCopy(result.address!, "address")}
-                      className="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                    >
-                      {copied === "address" ? (
-                        <Check className="h-3.5 w-3.5 text-green-500" />
-                      ) : (
-                        <Copy className="h-3.5 w-3.5" />
-                      )}
-                    </button>
-                  </div>
+              </button>
+            </div>
+          )}
+
+          {result.ensName && result.address && (
+            <div className="flex justify-center" aria-hidden="true">
+              <ArrowDownUp size={14} className="text-gray-400 dark:text-gray-500" />
+            </div>
+          )}
+
+          {/* Address block */}
+          {result.address && (
+            <div className="flex items-start gap-3 rounded-xl bg-gray-50 px-3.5 py-3 dark:bg-gray-900">
+              <div className="min-w-0 flex-1">
+                <p className="text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                  Address
+                </p>
+                <p
+                  className="break-all font-mono text-xs text-gray-900 dark:text-gray-100"
+                  title={result.address}
+                >
+                  {result.ensName ? result.address : truncateAddress(result.address)}
+                </p>
+              </div>
+              <div className="flex shrink-0 flex-col gap-1">
+                <button
+                  onClick={() => handleCopy(result.address!, "address")}
+                  className="rounded-md p-1.5 text-gray-400 hover:bg-white hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                  title="Copy address"
+                >
+                  {copied === "address" ? (
+                    <Check className="h-3.5 w-3.5 text-green-500" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+                {explorerUrl && (
+                  <a
+                    href={`${explorerUrl}${result.address}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-md p-1.5 text-gray-400 hover:bg-white hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+                    title="View on explorer"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
                 )}
               </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div className="border-t border-gray-100 px-5 py-3 text-center dark:border-gray-800">
+        <span className="text-xs text-gray-400 dark:text-gray-500">{footerText}</span>
       </div>
     </div>
   );
 }
+
+export default ENSResolver;

--- a/registry/w3-kit/ens-resolver/types.ts
+++ b/registry/w3-kit/ens-resolver/types.ts
@@ -7,5 +7,11 @@ export interface ENSResult {
 export interface ENSResolverProps {
   onResolve?: (result: ENSResult) => void;
   resolver?: (input: string) => Promise<ENSResult>;
+  /** Suggested ENS names shown in the idle state */
+  suggestions?: string[];
+  /** Block explorer base URL for the address external link (e.g. "https://etherscan.io/address/") */
+  explorerUrl?: string;
+  /** Footer caption shown when idle (defaults to "Enter a name or address") */
+  idleCaption?: string;
   className?: string;
 }

--- a/registry/w3-kit/gas-calculator/gas-calculator.tsx
+++ b/registry/w3-kit/gas-calculator/gas-calculator.tsx
@@ -1,9 +1,17 @@
 "use client";
 
 import React from "react";
-import { Fuel, Clock, Zap, Gauge } from "lucide-react";
+import {
+  Fuel,
+  Clock,
+  Zap,
+  Gauge,
+  ArrowLeftRight,
+  Image as ImageIcon,
+  FileCode,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { GasCalculatorProps } from "./types";
+import type { GasCalculatorProps, GasTxType } from "./types";
 import { formatUsd } from "./utils";
 
 const speedIcons: Record<string, React.ElementType> = {
@@ -12,13 +20,27 @@ const speedIcons: Record<string, React.ElementType> = {
   Fast: Zap,
 };
 
+const txTypeIcons: Record<NonNullable<GasTxType["icon"]>, React.ElementType> = {
+  transfer: Zap,
+  swap: ArrowLeftRight,
+  nft: ImageIcon,
+  contract: FileCode,
+};
+
 export function GasCalculator({
   speeds,
   selectedSpeed,
   onSelect,
   ethPrice,
+  txTypes,
+  selectedTxType,
+  onSelectTxType,
+  baseFeeGwei,
+  network,
   className,
 }: GasCalculatorProps) {
+  const activeSpeed = speeds.find((s) => s.name === selectedSpeed) ?? speeds[0];
+  const activeTxType = txTypes?.find((t) => t.key === selectedTxType) ?? txTypes?.[0];
   return (
     <div
       className={cn(
@@ -30,7 +52,49 @@ export function GasCalculator({
       <div className="flex items-center gap-3 px-5 py-4">
         <Fuel className="h-5 w-5 text-gray-500 dark:text-gray-400" />
         <h3 className="text-base font-semibold text-gray-900 dark:text-white">Gas</h3>
+        {ethPrice != null && (
+          <span className="ml-auto font-mono text-xs text-gray-500 dark:text-gray-400">
+            ETH ${ethPrice.toLocaleString()}
+          </span>
+        )}
       </div>
+
+      {/* Transaction type (optional) */}
+      {txTypes && txTypes.length > 0 && (
+        <div className="px-4 pb-3">
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            Transaction Type
+          </p>
+          <div className="flex gap-1.5">
+            {txTypes.map((t) => {
+              const isActive = (selectedTxType ?? txTypes[0].key) === t.key;
+              const Icon = t.icon ? txTypeIcons[t.icon] : Zap;
+              return (
+                <button
+                  key={t.key}
+                  type="button"
+                  onClick={() => onSelectTxType?.(t)}
+                  className={cn(
+                    "flex flex-1 flex-col items-center gap-1 rounded-lg px-1 py-2 text-[11px] font-medium transition-colors",
+                    isActive
+                      ? "border border-blue-500 bg-blue-50 text-gray-900 dark:border-blue-400 dark:bg-blue-950/40 dark:text-white"
+                      : "border border-gray-200 bg-transparent text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-900",
+                  )}
+                  aria-pressed={isActive}
+                >
+                  <Icon
+                    className={cn(
+                      "h-3.5 w-3.5",
+                      isActive ? "text-blue-600 dark:text-blue-400" : "text-gray-400",
+                    )}
+                  />
+                  {t.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Speed cards */}
       <div className="space-y-1.5 px-4 pb-4">
@@ -104,6 +168,46 @@ export function GasCalculator({
           );
         })}
       </div>
+
+      {/* Cost breakdown (optional) */}
+      {activeSpeed && (activeTxType || baseFeeGwei != null) && (
+        <div className="mx-4 mb-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-800 dark:bg-gray-900/60">
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+              Estimated Cost
+            </span>
+            {activeTxType && (
+              <span className="font-mono text-[11px] text-gray-500 dark:text-gray-400">
+                {activeTxType.gasLimit.toLocaleString()} gas
+              </span>
+            )}
+          </div>
+          <div className="mt-1.5 flex items-baseline gap-2">
+            <span className="font-mono text-base font-bold text-gray-900 dark:text-white">
+              {activeSpeed.cost} ETH
+            </span>
+            {ethPrice != null && (
+              <span className="text-xs text-gray-600 dark:text-gray-400">
+                {formatUsd(parseFloat(activeSpeed.cost) * ethPrice)}
+              </span>
+            )}
+          </div>
+          {baseFeeGwei != null && (
+            <div className="mt-2 flex gap-4 text-[11px] text-gray-500 dark:text-gray-400">
+              <span>Base: {baseFeeGwei} gwei</span>
+              <span>Priority: {Math.max(0, activeSpeed.gwei - baseFeeGwei)} gwei</span>
+              <span>Total: {activeSpeed.gwei} gwei</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Footer */}
+      {network && (
+        <div className="border-t border-gray-200 px-4 py-2.5 text-center dark:border-gray-800">
+          <p className="text-xs text-gray-500 dark:text-gray-400">{network}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/gas-calculator/types.ts
+++ b/registry/w3-kit/gas-calculator/types.ts
@@ -5,10 +5,23 @@ export interface GasSpeed {
   cost: string;
 }
 
+export interface GasTxType {
+  key: string;
+  label: string;
+  icon?: "transfer" | "swap" | "nft" | "contract";
+  gasLimit: number;
+}
+
 export interface GasCalculatorProps {
   speeds: GasSpeed[];
   selectedSpeed?: string;
   onSelect?: (speed: GasSpeed) => void;
   ethPrice?: number;
+  txTypes?: GasTxType[];
+  selectedTxType?: string;
+  onSelectTxType?: (txType: GasTxType) => void;
+  baseFeeGwei?: number;
+  /** Network name shown in the footer when set (e.g. `"Ethereum mainnet"`). */
+  network?: string;
   className?: string;
 }

--- a/registry/w3-kit/multisig-wallet/multisig-wallet.tsx
+++ b/registry/w3-kit/multisig-wallet/multisig-wallet.tsx
@@ -99,7 +99,14 @@ export function MultisigWallet({
             >
               {t}
               {t === "pending" && pendingCount > 0 && (
-                <span className="ml-1 rounded-full bg-white/20 px-1.5 text-[10px]">
+                <span
+                  className={cn(
+                    "ml-1 rounded-full px-1.5 text-[10px]",
+                    tab === t
+                      ? "bg-white/20 dark:bg-gray-900/20"
+                      : "bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
+                  )}
+                >
                   {pendingCount}
                 </span>
               )}
@@ -146,13 +153,20 @@ export function MultisigWallet({
             <div className="mt-2.5 flex items-center gap-3">
               <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
                 <div
-                  className="h-full rounded-full bg-gray-900 transition-all dark:bg-gray-100"
+                  className={cn(
+                    "h-full rounded-full transition-all",
+                    tx.status === "executed"
+                      ? "bg-green-500"
+                      : tx.status === "rejected"
+                        ? "bg-red-500"
+                        : "bg-gray-900 dark:bg-gray-100",
+                  )}
                   style={{
                     width: `${Math.min((tx.approvals / tx.requiredApprovals) * 100, 100)}%`,
                   }}
                 />
               </div>
-              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+              <span className="shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400">
                 {tx.approvals}/{tx.requiredApprovals}
               </span>
             </div>

--- a/registry/w3-kit/network-switcher/network-switcher.tsx
+++ b/registry/w3-kit/network-switcher/network-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useMemo } from "react";
-import { Check, Loader2, Search, X } from "lucide-react";
+import { Check, ChevronRight, Loader2, Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { NetworkSwitcherProps, Network } from "./types";
 
@@ -84,28 +84,30 @@ export function NetworkSwitcher({
     >
       {/* Header */}
       <div className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
-        <div className="flex items-center gap-2.5">
-          <span className="text-base font-semibold text-gray-900 dark:text-gray-100">Network</span>
+        <span className="text-base font-semibold text-gray-900 dark:text-gray-100">Network</span>
+        <div className="flex items-center gap-2">
           {activeNetwork && (
-            <div className="flex items-center gap-1.5">
+            <div className="flex items-center gap-1.5 rounded-lg bg-gray-100 px-2.5 py-1 dark:bg-gray-800">
               <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
-              <span className="text-xs text-gray-500 dark:text-gray-400">{activeNetwork.name}</span>
+              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+                {activeNetwork.name}
+              </span>
             </div>
           )}
+          {shouldShowToggle && (
+            <button
+              onClick={() => setShowTestnets(!showTestnets)}
+              className={cn(
+                "rounded-lg px-2.5 py-1 text-xs font-medium transition-colors",
+                showTestnets
+                  ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
+                  : "border border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600",
+              )}
+            >
+              Testnets
+            </button>
+          )}
         </div>
-        {shouldShowToggle && (
-          <button
-            onClick={() => setShowTestnets(!showTestnets)}
-            className={cn(
-              "rounded-lg px-2.5 py-1 text-xs font-medium transition-colors",
-              showTestnets
-                ? "bg-gray-900 text-white dark:bg-white dark:text-gray-900"
-                : "border border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600",
-            )}
-          >
-            Testnets
-          </button>
-        )}
       </div>
 
       {/* Search */}
@@ -156,9 +158,14 @@ export function NetworkSwitcher({
             >
               <NetworkIcon network={network} size={28} />
               <div className="flex-1 min-w-0">
-                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                <span className="block text-sm font-medium text-gray-900 dark:text-gray-100">
                   {network.name}
                 </span>
+                {(network.currency || network.symbol) && (
+                  <span className="block text-xs text-gray-500 dark:text-gray-400">
+                    {network.currency ?? network.symbol}
+                  </span>
+                )}
               </div>
               <span className="font-mono text-[11px] text-gray-400 dark:text-gray-500">
                 {network.chainId}
@@ -167,7 +174,13 @@ export function NetworkSwitcher({
                 <Loader2 size={14} className="shrink-0 animate-spin text-gray-400" />
               ) : isActive ? (
                 <Check size={14} className="shrink-0 text-gray-900 dark:text-gray-100" />
-              ) : null}
+              ) : (
+                <ChevronRight
+                  size={14}
+                  className="shrink-0 text-gray-300 dark:text-gray-600"
+                  aria-hidden="true"
+                />
+              )}
             </button>
           );
         })}

--- a/registry/w3-kit/nft-card/nft-card.tsx
+++ b/registry/w3-kit/nft-card/nft-card.tsx
@@ -97,6 +97,14 @@ export function NFTCard({ nft, onClick, className }: NFTCardProps) {
           </div>
         )}
       </div>
+
+      {nft.collection && (
+        <div className="border-t border-gray-200 px-4 py-2.5 text-center dark:border-gray-800">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {nft.collection} Collection
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/nft-marketplace-aggregator/nft-marketplace-aggregator.tsx
+++ b/registry/w3-kit/nft-marketplace-aggregator/nft-marketplace-aggregator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo } from "react";
-import { Store, BadgeCheck, ShoppingCart, ImageOff } from "lucide-react";
+import { Store, BadgeCheck, ShoppingCart, ImageOff, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { NFTListing, NFTMarketplaceAggregatorProps } from "./types";
 import { findBestPriceListing } from "./utils";
@@ -130,7 +130,32 @@ export function NFTMarketplaceAggregator({
                     {listing.usdPrice}
                   </span>
                 )}
+                {(listing.rank !== undefined || listing.rarity !== undefined) && (
+                  <span className="text-[11px] tabular-nums text-gray-400 dark:text-gray-500">
+                    {listing.rank !== undefined
+                      ? `Rank #${listing.rank}`
+                      : `${(listing.rarity! * 100).toFixed(2)}%`}
+                  </span>
+                )}
+                {listing.lastUpdate && (
+                  <span className="text-[11px] tabular-nums text-gray-400 dark:text-gray-500">
+                    {listing.lastUpdate}
+                  </span>
+                )}
               </div>
+
+              {/* View link */}
+              {listing.link && (
+                <a
+                  href={listing.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`View on ${listing.marketplace}`}
+                  className="ml-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </a>
+              )}
 
               {/* Buy button */}
               {onBuy && (

--- a/registry/w3-kit/nft-marketplace-aggregator/types.ts
+++ b/registry/w3-kit/nft-marketplace-aggregator/types.ts
@@ -9,6 +9,10 @@ export interface NFTListing {
   currency?: string;
   usdPrice?: string;
   verified?: boolean;
+  rank?: number;
+  rarity?: number;
+  lastUpdate?: string;
+  link?: string;
 }
 
 export interface NFTMarketplaceAggregatorProps {

--- a/registry/w3-kit/price-ticker/price-ticker.tsx
+++ b/registry/w3-kit/price-ticker/price-ticker.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 import React from "react";
-import { TrendingUp } from "lucide-react";
+import { TrendingUp, TrendingDown } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { PriceTickerProps } from "./types";
-import { formatCurrency, formatPercent, formatMarketCap } from "./utils";
+import type { PriceTickerProps, TickerToken } from "./types";
+import { formatCurrency, formatPercent, formatMarketCap, sparklinePath } from "./utils";
 
-export function PriceTicker({ tokens, onTokenClick, className }: PriceTickerProps) {
+export function PriceTicker({
+  tokens,
+  onTokenClick,
+  emptyMessage = "No tokens to display",
+  className,
+}: PriceTickerProps) {
   return (
     <div
       className={cn(
@@ -22,55 +27,86 @@ export function PriceTicker({ tokens, onTokenClick, className }: PriceTickerProp
 
       {/* Token rows */}
       <ul className="divide-y divide-gray-100 dark:divide-gray-800">
-        {tokens.map((token) => (
-          <li
-            key={token.symbol}
-            className={cn(
-              "flex items-center gap-3 px-4 py-3 transition-colors",
-              onTokenClick && "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900",
-            )}
-            onClick={() => onTokenClick?.(token)}
-          >
-            {/* Logo */}
-            {token.logoURI ? (
-              <img src={token.logoURI} alt={token.symbol} className="h-8 w-8 rounded-full" />
-            ) : (
-              <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600 dark:bg-gray-800 dark:text-gray-300">
-                {token.symbol.slice(0, 2)}
-              </div>
-            )}
-
-            {/* Name + symbol */}
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{token.name}</p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">{token.symbol}</p>
-            </div>
-
-            {/* Price */}
-            <p className="text-sm font-medium tabular-nums text-gray-900 dark:text-gray-100">
-              {formatCurrency(token.price)}
-            </p>
-
-            {/* 24h change pill */}
-            <span
-              className={cn(
-                "inline-flex min-w-[4.5rem] items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium",
-                token.priceChange24h >= 0
-                  ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                  : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-              )}
-            >
-              {formatPercent(token.priceChange24h)}
-            </span>
-
-            {/* Market cap (optional) */}
-            {token.marketCap !== undefined && (
-              <p className="hidden min-w-[4rem] text-right text-xs text-gray-500 dark:text-gray-400 sm:block">
-                {formatMarketCap(token.marketCap)}
-              </p>
-            )}
+        {tokens.length === 0 && (
+          <li className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            {emptyMessage}
           </li>
-        ))}
+        )}
+        {tokens.map((token: TickerToken) => {
+          const positive = token.priceChange24h >= 0;
+          const TrendIcon = positive ? TrendingUp : TrendingDown;
+          return (
+            <li
+              key={token.symbol}
+              className={cn(
+                "flex items-center gap-3 px-4 py-3 transition-colors",
+                onTokenClick && "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900",
+              )}
+              onClick={() => onTokenClick?.(token)}
+            >
+              {/* Logo */}
+              {token.logoURI ? (
+                <img src={token.logoURI} alt={token.symbol} className="h-8 w-8 rounded-full" />
+              ) : (
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                  {token.symbol.slice(0, 2)}
+                </div>
+              )}
+
+              {/* Name + symbol + market cap */}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{token.name}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {token.symbol}
+                  {token.marketCap !== undefined && (
+                    <>
+                      <span className="mx-1.5">·</span>
+                      {formatMarketCap(token.marketCap)}
+                    </>
+                  )}
+                </p>
+              </div>
+
+              {/* Sparkline (optional) */}
+              {token.sparkline && token.sparkline.length > 1 && (
+                <svg
+                  aria-hidden="true"
+                  viewBox="0 0 60 20"
+                  className={cn(
+                    "hidden h-5 w-14 shrink-0 sm:block",
+                    positive ? "text-green-500" : "text-red-500",
+                  )}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d={sparklinePath(token.sparkline, 60, 20)} />
+                </svg>
+              )}
+
+              {/* Price + change pill */}
+              <div className="flex flex-col items-end gap-0.5">
+                <p className="text-sm font-medium tabular-nums text-gray-900 dark:text-gray-100">
+                  {formatCurrency(token.price)}
+                </p>
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-medium tabular-nums",
+                    positive
+                      ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                      : "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+                  )}
+                  aria-label={`${positive ? "Up" : "Down"} ${Math.abs(token.priceChange24h).toFixed(2)} percent in 24 hours`}
+                >
+                  <TrendIcon className="h-3 w-3" aria-hidden="true" />
+                  {formatPercent(token.priceChange24h)}
+                </span>
+              </div>
+            </li>
+          );
+        })}
       </ul>
 
       {/* Footer */}

--- a/registry/w3-kit/price-ticker/types.ts
+++ b/registry/w3-kit/price-ticker/types.ts
@@ -6,10 +6,13 @@ export interface TickerToken {
   marketCap?: number;
   volume24h?: number;
   logoURI?: string;
+  /** Recent price points used to render the inline trend sparkline. */
+  sparkline?: number[];
 }
 
 export interface PriceTickerProps {
   tokens: TickerToken[];
   onTokenClick?: (token: TickerToken) => void;
+  emptyMessage?: string;
   className?: string;
 }

--- a/registry/w3-kit/price-ticker/utils.ts
+++ b/registry/w3-kit/price-ticker/utils.ts
@@ -12,8 +12,29 @@ export function formatPercent(value: number): string {
 }
 
 export function formatMarketCap(value: number): string {
+  if (value >= 1_000_000_000_000) return `$${(value / 1_000_000_000_000).toFixed(2)}T`;
   if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
   if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
   return `$${value.toFixed(0)}`;
+}
+
+export function sparklinePath(points: number[], width: number, height: number): string {
+  if (points.length < 2) return "";
+  let min = points[0];
+  let max = points[0];
+  for (let i = 1; i < points.length; i++) {
+    const p = points[i];
+    if (p < min) min = p;
+    if (p > max) max = p;
+  }
+  const range = max - min || 1;
+  const stepX = width / (points.length - 1);
+  return points
+    .map((value, i) => {
+      const x = i * stepX;
+      const y = height - ((value - min) / range) * height;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
 }

--- a/registry/w3-kit/smart-contract-scanner/smart-contract-scanner.tsx
+++ b/registry/w3-kit/smart-contract-scanner/smart-contract-scanner.tsx
@@ -24,27 +24,60 @@ const statusBadge = {
   danger: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-400",
 } as const;
 
-function scoreColor(score: number) {
-  if (score > 70) return "border-green-500 text-green-600 dark:text-green-400";
-  if (score > 40) return "border-amber-500 text-amber-600 dark:text-amber-400";
-  return "border-red-500 text-red-600 dark:text-red-400";
+type RiskTier = "low" | "medium" | "high";
+
+function riskTier(score: number): RiskTier {
+  if (score > 70) return "low";
+  if (score > 40) return "medium";
+  return "high";
 }
+
+const riskTierLabel: Record<RiskTier, string> = {
+  low: "Low Risk",
+  medium: "Medium Risk",
+  high: "High Risk",
+};
+
+const riskTierBorder: Record<RiskTier, string> = {
+  low: "border-green-500 text-green-600 dark:text-green-400",
+  medium: "border-amber-500 text-amber-600 dark:text-amber-400",
+  high: "border-red-500 text-red-600 dark:text-red-400",
+};
+
+const riskTierText: Record<RiskTier, string> = {
+  low: "text-green-600 dark:text-green-400",
+  medium: "text-amber-600 dark:text-amber-400",
+  high: "text-red-600 dark:text-red-400",
+};
 
 export function SmartContractScanner({
   address,
   score,
   checks,
+  riskLabel,
+  exampleAddress,
   onScan,
+  onReset,
   loading = false,
   className,
 }: SmartContractScannerProps) {
   const [input, setInput] = useState("");
   const hasResults = score !== undefined && checks !== undefined;
   const passedCount = checks?.filter((c) => c.status === "safe").length ?? 0;
+  const warningCount = checks?.filter((c) => c.status === "warning").length ?? 0;
+  const dangerCount = checks?.filter((c) => c.status === "danger").length ?? 0;
+  const totalChecks = checks?.length ?? 0;
+  const tier = score !== undefined ? riskTier(score) : undefined;
+  const resolvedRiskLabel = riskLabel ?? (tier ? riskTierLabel[tier] : undefined);
 
   const handleScan = () => {
     const value = input.trim();
     if (value && onScan) onScan(value);
+  };
+
+  const handleReset = () => {
+    setInput("");
+    onReset?.();
   };
 
   return (
@@ -59,31 +92,56 @@ export function SmartContractScanner({
         <Shield className="h-4 w-4 text-gray-500 dark:text-gray-400" />
         <span className="text-sm font-medium text-gray-900 dark:text-white">Scanner</span>
         {address && (
-          <span className="ml-auto rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+          <span className="rounded-md bg-gray-100 px-2 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400">
             {truncateAddress(address)}
           </span>
+        )}
+        {hasResults && onReset && (
+          <button
+            type="button"
+            onClick={handleReset}
+            className="ml-auto text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+          >
+            New scan
+          </button>
         )}
       </div>
 
       <div className="px-4 pb-4 space-y-4">
         {/* Input state — no results yet */}
         {!hasResults && !loading && (
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleScan()}
-              placeholder="0x..."
-              className="flex-1 rounded-lg border border-gray-200 bg-transparent px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
-            />
-            <button
-              onClick={handleScan}
-              disabled={!input.trim()}
-              className="rounded-lg bg-gray-900 px-3 py-2 text-white transition-colors hover:bg-gray-800 disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
-            >
-              <Search className="h-4 w-4" />
-            </button>
+          <div className="space-y-2">
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleScan()}
+                placeholder="0x..."
+                aria-label="Contract address"
+                className="flex-1 rounded-lg border border-gray-200 bg-transparent px-3 py-2 font-mono text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
+              />
+              <button
+                onClick={handleScan}
+                disabled={!input.trim()}
+                aria-label="Scan contract"
+                className="rounded-lg bg-gray-900 px-3 py-2 text-white transition-colors hover:bg-gray-800 disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+              >
+                <Search className="h-4 w-4" />
+              </button>
+            </div>
+            {exampleAddress && (
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Try:{" "}
+                <button
+                  type="button"
+                  onClick={() => setInput(exampleAddress)}
+                  className="font-mono text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+                >
+                  {truncateAddress(exampleAddress)}
+                </button>
+              </p>
+            )}
           </div>
         )}
 
@@ -97,17 +155,44 @@ export function SmartContractScanner({
         {/* Results */}
         {hasResults && !loading && (
           <>
-            {/* Score circle */}
-            <div className="flex justify-center py-2">
+            {/* Score circle + risk label */}
+            <div className="flex flex-col items-center gap-1 py-2">
               <div
                 className={cn(
                   "flex h-20 w-20 items-center justify-center rounded-full border-4",
-                  scoreColor(score),
+                  tier && riskTierBorder[tier],
                 )}
               >
                 <span className="text-2xl font-bold tabular-nums">{score}</span>
               </div>
+              {resolvedRiskLabel && tier && (
+                <span className={cn("text-xs font-medium", riskTierText[tier])}>
+                  {resolvedRiskLabel}
+                </span>
+              )}
             </div>
+
+            {/* Findings strip */}
+            {totalChecks > 0 && (
+              <div className="flex justify-center gap-3 text-xs text-gray-600 dark:text-gray-400">
+                <span className="flex items-center gap-1">
+                  <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+                  {passedCount} passed
+                </span>
+                {warningCount > 0 && (
+                  <span className="flex items-center gap-1">
+                    <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                    {warningCount} warning{warningCount !== 1 ? "s" : ""}
+                  </span>
+                )}
+                {dangerCount > 0 && (
+                  <span className="flex items-center gap-1">
+                    <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+                    {dangerCount} critical
+                  </span>
+                )}
+              </div>
+            )}
 
             {/* Check list */}
             <ul className="space-y-1.5">
@@ -145,13 +230,15 @@ export function SmartContractScanner({
       </div>
 
       {/* Footer */}
-      {hasResults && !loading && (
-        <div className="border-t border-gray-100 px-4 py-2.5 dark:border-gray-800">
-          <p className="text-xs text-gray-500 dark:text-gray-400">
-            {passedCount} check{passedCount !== 1 ? "s" : ""} passed
-          </p>
-        </div>
-      )}
+      <div className="border-t border-gray-100 px-4 py-2.5 text-center dark:border-gray-800">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {hasResults && !loading
+            ? `${passedCount}/${totalChecks} checks passed`
+            : loading
+              ? "Scanning…"
+              : "Paste a contract address to scan"}
+        </p>
+      </div>
     </div>
   );
 }

--- a/registry/w3-kit/smart-contract-scanner/types.ts
+++ b/registry/w3-kit/smart-contract-scanner/types.ts
@@ -10,7 +10,10 @@ export interface SmartContractScannerProps {
   address?: string;
   score?: number;
   checks?: SecurityCheck[];
+  riskLabel?: string; // e.g. "Low Risk", overrides auto-derived label
+  exampleAddress?: string; // shown as a "Try: ..." quick-fill on idle
   onScan?: (address: string) => void;
+  onReset?: () => void;
   loading?: boolean;
   className?: string;
 }

--- a/registry/w3-kit/staking-interface/staking-interface.tsx
+++ b/registry/w3-kit/staking-interface/staking-interface.tsx
@@ -11,6 +11,8 @@ export function StakingInterface({
   onStake,
   onUnstake,
   stakingPoolId,
+  footerLabel,
+  emptyMessage = "No staking pools available",
   className,
 }: StakingInterfaceProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -50,6 +52,11 @@ export function StakingInterface({
 
       {/* Pool list */}
       <div className="divide-y divide-gray-100 dark:divide-gray-800/60">
+        {pools.length === 0 && (
+          <p className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            {emptyMessage}
+          </p>
+        )}
         {pools.map((pool) => {
           const expanded = expandedId === pool.id;
           const loading = stakingPoolId === pool.id;
@@ -175,6 +182,13 @@ export function StakingInterface({
           );
         })}
       </div>
+
+      {/* Footer */}
+      {footerLabel && (
+        <div className="border-t border-gray-200 px-4 py-2.5 text-center dark:border-gray-800">
+          <p className="text-xs text-gray-500 dark:text-gray-400">{footerLabel}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/staking-interface/types.ts
+++ b/registry/w3-kit/staking-interface/types.ts
@@ -15,5 +15,7 @@ export interface StakingInterfaceProps {
   onStake?: (poolId: string, amount: string) => void;
   onUnstake?: (poolId: string, amount: string) => void;
   stakingPoolId?: string; // pool currently being staked to (loading)
+  footerLabel?: string; // optional caption shown in the footer strip
+  emptyMessage?: string; // shown when pools is empty
   className?: string;
 }

--- a/registry/w3-kit/subscription-payments/subscription-payments.tsx
+++ b/registry/w3-kit/subscription-payments/subscription-payments.tsx
@@ -10,6 +10,8 @@ export function SubscriptionPayments({
   plans,
   onSubscribe,
   subscribingId,
+  subscribedId,
+  emptyMessage = "No plans available",
   className,
 }: SubscriptionPaymentsProps) {
   return (
@@ -27,17 +29,25 @@ export function SubscriptionPayments({
 
       {/* Plan cards */}
       <div className="space-y-2 px-4 pb-4">
+        {plans.length === 0 && (
+          <p className="py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            {emptyMessage}
+          </p>
+        )}
         {plans.map((plan) => {
           const isSubscribing = subscribingId === plan.id;
+          const isSubscribed = subscribedId === plan.id;
 
           return (
             <div
               key={plan.id}
               className={cn(
                 "rounded-xl px-3 py-3 transition-colors",
-                plan.popular
-                  ? "border border-gray-900 bg-gray-50 dark:border-white dark:bg-gray-900"
-                  : "bg-gray-50 dark:bg-gray-900",
+                isSubscribed
+                  ? "border border-green-500 bg-green-50 dark:border-green-400 dark:bg-green-950/20"
+                  : plan.popular
+                    ? "border border-gray-900 bg-gray-50 dark:border-white dark:bg-gray-900"
+                    : "bg-gray-50 dark:bg-gray-900",
               )}
             >
               {/* Plan header */}
@@ -50,9 +60,15 @@ export function SubscriptionPayments({
                       Popular
                     </span>
                   )}
+                  {isSubscribed && (
+                    <span className="flex items-center gap-0.5 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold text-green-800 dark:bg-green-900/40 dark:text-green-400">
+                      <Check className="h-3 w-3" />
+                      Active
+                    </span>
+                  )}
                 </div>
                 <div className="flex items-baseline gap-1">
-                  <span className="text-base font-semibold text-gray-900 dark:text-white">
+                  <span className="text-base font-semibold tabular-nums text-gray-900 dark:text-white">
                     {plan.price}
                   </span>
                   <span className="text-xs text-gray-500 dark:text-gray-400">
@@ -61,6 +77,10 @@ export function SubscriptionPayments({
                   </span>
                 </div>
               </div>
+
+              {plan.description && (
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{plan.description}</p>
+              )}
 
               {/* Features */}
               {plan.features.length > 0 && (
@@ -80,21 +100,42 @@ export function SubscriptionPayments({
               {/* Subscribe button */}
               <button
                 onClick={() => onSubscribe?.(plan.id)}
-                disabled={isSubscribing}
+                disabled={isSubscribing || isSubscribed}
                 className={cn(
                   "mt-3 flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                  plan.popular
-                    ? "bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
-                    : "bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700",
-                  isSubscribing && "cursor-not-allowed opacity-60",
+                  isSubscribed
+                    ? "bg-green-600 text-white dark:bg-green-500"
+                    : plan.popular
+                      ? "bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200"
+                      : "bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700",
+                  (isSubscribing || isSubscribed) && "cursor-not-allowed",
+                  isSubscribing && "opacity-60",
                 )}
               >
-                {isSubscribing ? <Loader2 className="h-4 w-4 animate-spin" /> : "Subscribe"}
+                {isSubscribed ? (
+                  <>
+                    <Check className="h-4 w-4" />
+                    Subscribed
+                  </>
+                ) : isSubscribing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  "Subscribe"
+                )}
               </button>
             </div>
           );
         })}
       </div>
+
+      {/* Footer */}
+      {plans.length > 0 && (
+        <div className="border-t border-gray-200 px-4 py-2.5 text-center dark:border-gray-800">
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {plans.length} plan{plans.length !== 1 ? "s" : ""} available
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/subscription-payments/types.ts
+++ b/registry/w3-kit/subscription-payments/types.ts
@@ -6,11 +6,14 @@ export interface Plan {
   interval: string;
   features: string[];
   popular?: boolean;
+  description?: string;
 }
 
 export interface SubscriptionPaymentsProps {
   plans: Plan[];
   onSubscribe?: (planId: string) => void;
   subscribingId?: string;
+  subscribedId?: string; // plan the user is currently subscribed to
+  emptyMessage?: string;
   className?: string;
 }

--- a/registry/w3-kit/token-airdrop/token-airdrop.tsx
+++ b/registry/w3-kit/token-airdrop/token-airdrop.tsx
@@ -6,7 +6,16 @@ import { cn } from "@/lib/utils";
 import type { TokenAirdropProps } from "./types";
 import { statusColor } from "./utils";
 
-export function TokenAirdrop({ airdrops, onClaim, claimingId, className }: TokenAirdropProps) {
+export function TokenAirdrop({
+  airdrops,
+  onClaim,
+  claimingId,
+  showFooter = false,
+  showActiveCount = false,
+  className,
+}: TokenAirdropProps) {
+  const activeCount = airdrops.filter((a) => a.status === "active").length;
+
   return (
     <div
       className={cn(
@@ -18,9 +27,15 @@ export function TokenAirdrop({ airdrops, onClaim, claimingId, className }: Token
       <div className="flex items-center gap-3 px-5 py-4">
         <Gift className="h-5 w-5 text-gray-500 dark:text-gray-400" />
         <h3 className="text-base font-semibold text-gray-900 dark:text-white">Airdrops</h3>
-        <span className="ml-auto rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-          {airdrops.length}
-        </span>
+        {showActiveCount ? (
+          <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+            {activeCount} claimable
+          </span>
+        ) : (
+          <span className="ml-auto rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {airdrops.length}
+          </span>
+        )}
       </div>
 
       {/* Airdrop list */}
@@ -36,12 +51,22 @@ export function TokenAirdrop({ airdrops, onClaim, claimingId, className }: Token
           const isActive = airdrop.status === "active";
 
           return (
-            <div key={airdrop.id} className="rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-gray-900">
-              <div className="flex items-center justify-between">
+            <div
+              key={airdrop.id}
+              className="flex items-center gap-3 rounded-xl bg-gray-50 px-3 py-2.5 dark:bg-gray-900"
+            >
+              {airdrop.logoURI && (
+                <img
+                  src={airdrop.logoURI}
+                  alt={airdrop.token}
+                  className="h-8 w-8 shrink-0 rounded-full"
+                />
+              )}
+              <div className="flex flex-1 items-center justify-between">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <p className="text-sm font-medium text-gray-900 dark:text-white">
-                      {airdrop.amount} {airdrop.token}
+                      {airdrop.name ?? `${airdrop.amount} ${airdrop.token}`}
                     </p>
                     <span
                       className={cn(
@@ -53,6 +78,11 @@ export function TokenAirdrop({ airdrops, onClaim, claimingId, className }: Token
                     </span>
                   </div>
                   <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {airdrop.name && (
+                      <span className="tabular-nums">
+                        {airdrop.amount} {airdrop.token} ·{" "}
+                      </span>
+                    )}
                     {airdrop.startDate} - {airdrop.endDate}
                   </p>
                 </div>
@@ -74,6 +104,14 @@ export function TokenAirdrop({ airdrops, onClaim, claimingId, className }: Token
           );
         })}
       </div>
+
+      {showFooter && (
+        <div className="border-t border-gray-200 px-5 py-3 text-center dark:border-gray-800">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {airdrops.length} airdrop{airdrops.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/token-airdrop/types.ts
+++ b/registry/w3-kit/token-airdrop/types.ts
@@ -5,11 +5,19 @@ export interface Airdrop {
   status: "active" | "claimed" | "expired";
   startDate: string;
   endDate: string;
+  /** Optional display name shown above the amount line */
+  name?: string;
+  /** Optional token logo URL */
+  logoURI?: string;
 }
 
 export interface TokenAirdropProps {
   airdrops: Airdrop[];
   onClaim?: (airdropId: string) => void;
   claimingId?: string;
+  /** Show footer with airdrop count */
+  showFooter?: boolean;
+  /** Show count of active airdrops in the header (instead of total) */
+  showActiveCount?: boolean;
   className?: string;
 }

--- a/registry/w3-kit/token-card/token-card.tsx
+++ b/registry/w3-kit/token-card/token-card.tsx
@@ -48,6 +48,17 @@ export function TokenCard({ token, onClick, className }: TokenCardProps) {
         <p className="text-2xl font-bold tabular-nums text-gray-900 dark:text-gray-100">
           {formatCurrency(token.price)}
         </p>
+        {token.priceChange24h !== undefined && (
+          <p
+            className={cn(
+              "mt-0.5 text-sm font-medium",
+              change >= 0 ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400",
+            )}
+          >
+            {formatPercent(change)}{" "}
+            <span className="text-xs font-normal text-gray-500 dark:text-gray-400">24h</span>
+          </p>
+        )}
       </div>
 
       {/* Stat grid */}

--- a/registry/w3-kit/token-list/token-list.tsx
+++ b/registry/w3-kit/token-list/token-list.tsx
@@ -25,48 +25,52 @@ export function TokenList({ tokens, onTokenSelect, className }: TokenListProps) 
       </div>
 
       {/* Token rows */}
-      <ul className="divide-y divide-gray-100 dark:divide-gray-800">
-        {sorted.map((token) => {
-          const value = token.balance * token.price;
-          return (
-            <li
-              key={token.symbol}
-              className={cn(
-                "flex items-center gap-3 px-4 py-3 transition-colors",
-                onTokenSelect && "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900",
-              )}
-              onClick={() => onTokenSelect?.(token)}
-            >
-              {/* Logo */}
-              {token.logoURI ? (
-                <img src={token.logoURI} alt={token.symbol} className="h-8 w-8 rounded-full" />
-              ) : (
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600 dark:bg-gray-800 dark:text-gray-300">
-                  {token.symbol.slice(0, 2)}
+      {sorted.length === 0 ? (
+        <p className="px-4 py-8 text-center text-sm text-gray-400 dark:text-gray-500">No tokens</p>
+      ) : (
+        <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+          {sorted.map((token) => {
+            const value = token.balance * token.price;
+            return (
+              <li
+                key={token.symbol}
+                className={cn(
+                  "flex items-center gap-3 px-4 py-3 transition-colors",
+                  onTokenSelect && "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900",
+                )}
+                onClick={() => onTokenSelect?.(token)}
+              >
+                {/* Logo */}
+                {token.logoURI ? (
+                  <img src={token.logoURI} alt={token.symbol} className="h-8 w-8 rounded-full" />
+                ) : (
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                    {token.symbol.slice(0, 2)}
+                  </div>
+                )}
+
+                {/* Symbol + name */}
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {token.symbol}
+                  </p>
+                  <p className="truncate text-xs text-gray-500 dark:text-gray-400">{token.name}</p>
                 </div>
-              )}
 
-              {/* Symbol + name */}
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {token.symbol}
+                {/* Balance */}
+                <p className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
+                  {token.balance.toFixed(4)}
                 </p>
-                <p className="truncate text-xs text-gray-500 dark:text-gray-400">{token.name}</p>
-              </div>
 
-              {/* Balance */}
-              <p className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
-                {token.balance.toFixed(4)}
-              </p>
-
-              {/* Value */}
-              <p className="min-w-[5rem] text-right text-sm font-medium tabular-nums text-gray-900 dark:text-gray-100">
-                {formatCurrency(value)}
-              </p>
-            </li>
-          );
-        })}
-      </ul>
+                {/* Value */}
+                <p className="min-w-[5rem] text-right text-sm font-medium tabular-nums text-gray-900 dark:text-gray-100">
+                  {formatCurrency(value)}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      )}
 
       {/* Footer */}
       <div className="flex items-center justify-between border-t border-gray-200 px-4 py-2.5 dark:border-gray-800">

--- a/registry/w3-kit/token-swap/token-swap.tsx
+++ b/registry/w3-kit/token-swap/token-swap.tsx
@@ -72,6 +72,8 @@ export function TokenSwap({
   exchangeRate,
   slippage,
   loading = false,
+  showRateInHeader = false,
+  showFooter = false,
   className,
 }: TokenSwapProps) {
   const [fromAmount, setFromAmount] = useState("");
@@ -105,10 +107,16 @@ export function TokenSwap({
       <div className="mb-4 flex items-center gap-2">
         <ArrowDownUp className="h-5 w-5" />
         <h2 className="text-base font-semibold">Swap</h2>
-        {slippage !== undefined && (
-          <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
-            Slippage {slippage}%
+        {showRateInHeader && fromToken && toToken && exchangeRate !== undefined ? (
+          <span className="ml-auto text-xs tabular-nums text-gray-500 dark:text-gray-400">
+            {formatRate(exchangeRate, fromToken.symbol, toToken.symbol)}
           </span>
+        ) : (
+          slippage !== undefined && (
+            <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+              Slippage {slippage}%
+            </span>
+          )
         )}
       </div>
 
@@ -210,10 +218,20 @@ export function TokenSwap({
             <Loader2 className="h-4 w-4 animate-spin" />
             Swapping...
           </>
+        ) : !fromAmount || parseFloat(fromAmount) <= 0 ? (
+          "Enter amount"
         ) : (
           "Swap"
         )}
       </button>
+
+      {showFooter && (
+        <div className="-mx-5 mt-4 border-t border-gray-200 px-5 pt-3 text-center dark:border-gray-800">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {tokens.length} token{tokens.length !== 1 ? "s" : ""} available
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/token-swap/types.ts
+++ b/registry/w3-kit/token-swap/types.ts
@@ -30,6 +30,10 @@ export interface TokenSwapProps {
   slippage?: number;
   /** Show loading state on swap button */
   loading?: boolean;
+  /** Show inline rate (1 from ≈ N to) in the header */
+  showRateInHeader?: boolean;
+  /** Show footer with available token count */
+  showFooter?: boolean;
   /** Additional CSS classes */
   className?: string;
 }

--- a/registry/w3-kit/token-vesting/token-vesting.tsx
+++ b/registry/w3-kit/token-vesting/token-vesting.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Clock, Loader2 } from "lucide-react";
+import { Check, Clock, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TokenVestingProps } from "./types";
 import { vestingPercent } from "./utils";
@@ -12,7 +12,15 @@ const statusColor: Record<string, string> = {
   pending: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
 };
 
-export function TokenVesting({ schedules, onClaim, claimingId, className }: TokenVestingProps) {
+export function TokenVesting({
+  schedules,
+  onClaim,
+  claimingId,
+  showCount = false,
+  showProgressLabels = false,
+  showFooter = false,
+  className,
+}: TokenVestingProps) {
   return (
     <div
       className={cn(
@@ -24,6 +32,11 @@ export function TokenVesting({ schedules, onClaim, claimingId, className }: Toke
       <div className="flex items-center gap-3 px-5 py-4">
         <Clock className="h-5 w-5 text-gray-500 dark:text-gray-400" />
         <h3 className="text-base font-semibold text-gray-900 dark:text-white">Vesting</h3>
+        {showCount && (
+          <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+            {schedules.length}
+          </span>
+        )}
       </div>
 
       {/* Schedule list */}
@@ -39,32 +52,62 @@ export function TokenVesting({ schedules, onClaim, claimingId, className }: Toke
           const pct = vestingPercent(schedule.vestedAmount, schedule.totalAmount);
           const isClaimable = schedule.status === "active" && pct < 100;
 
+          const totalNum = parseFloat(schedule.totalAmount) || 0;
+          const vestedNum = parseFloat(schedule.vestedAmount) || 0;
+          const remaining = Math.max(0, totalNum - vestedNum);
+          const fullyVested =
+            schedule.status === "completed" ||
+            (totalNum > 0 && pct >= 100 && !schedule.claimableAmount);
+
           return (
             <div key={schedule.id} className="rounded-xl bg-gray-50 px-3 py-3 dark:bg-gray-900">
               {/* Top row */}
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    {schedule.token}
+              <div className="flex items-center gap-2">
+                {schedule.logoURI && (
+                  <img
+                    src={schedule.logoURI}
+                    alt={schedule.token}
+                    className="h-7 w-7 shrink-0 rounded-full"
+                  />
+                )}
+                <div className="flex flex-1 items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium text-gray-900 dark:text-white">
+                      {schedule.token}
+                    </p>
+                    <span
+                      className={cn(
+                        "rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize",
+                        statusColor[schedule.status] ?? statusColor.pending,
+                      )}
+                    >
+                      {schedule.status}
+                    </span>
+                  </div>
+                  <p className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
+                    {schedule.vestedAmount} / {schedule.totalAmount}
                   </p>
-                  <span
-                    className={cn(
-                      "rounded-full px-2 py-0.5 text-[10px] font-semibold capitalize",
-                      statusColor[schedule.status] ?? statusColor.pending,
-                    )}
-                  >
-                    {schedule.status}
-                  </span>
                 </div>
-                <p className="text-xs tabular-nums text-gray-500 dark:text-gray-400">
-                  {schedule.vestedAmount} / {schedule.totalAmount}
-                </p>
               </div>
 
               {/* Progress bar */}
-              <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+              {showProgressLabels && (
+                <div className="mt-2 flex items-center justify-between text-[11px] tabular-nums text-gray-500 dark:text-gray-400">
+                  <span>{pct}% vested</span>
+                  <span>{remaining.toLocaleString("en-US")} remaining</span>
+                </div>
+              )}
+              <div
+                className={cn(
+                  "h-1.5 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700",
+                  showProgressLabels ? "mt-1" : "mt-2",
+                )}
+              >
                 <div
-                  className="h-full rounded-full bg-gray-900 transition-all duration-500 dark:bg-white"
+                  className={cn(
+                    "h-full rounded-full transition-all duration-500",
+                    schedule.status === "completed" ? "bg-green-500" : "bg-gray-900 dark:bg-white",
+                  )}
                   style={{ width: `${pct}%` }}
                 />
               </div>
@@ -85,13 +128,35 @@ export function TokenVesting({ schedules, onClaim, claimingId, className }: Toke
                     isClaiming && "cursor-not-allowed opacity-60",
                   )}
                 >
-                  {isClaiming ? <Loader2 className="h-4 w-4 animate-spin" /> : "Claim"}
+                  {isClaiming ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : schedule.claimableAmount ? (
+                    `Claim ${schedule.claimableAmount}`
+                  ) : (
+                    "Claim"
+                  )}
                 </button>
+              )}
+
+              {/* Completed message */}
+              {fullyVested && !isClaimable && (
+                <div className="mt-2.5 flex items-center justify-center gap-1.5 rounded-lg border border-green-500/20 bg-green-500/10 px-3 py-2 text-xs font-medium text-green-700 dark:text-green-400">
+                  <Check className="h-3.5 w-3.5" />
+                  Fully vested &amp; claimed
+                </div>
               )}
             </div>
           );
         })}
       </div>
+
+      {showFooter && (
+        <div className="border-t border-gray-200 px-5 py-3 text-center dark:border-gray-800">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {schedules.length} schedule{schedules.length !== 1 ? "s" : ""}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/registry/w3-kit/token-vesting/types.ts
+++ b/registry/w3-kit/token-vesting/types.ts
@@ -6,11 +6,21 @@ export interface VestingSchedule {
   cliffDate: string;
   endDate: string;
   status: "active" | "completed" | "pending";
+  /** Optional currently-claimable amount; surfaces a labeled claim CTA */
+  claimableAmount?: string;
+  /** Optional token logo URL */
+  logoURI?: string;
 }
 
 export interface TokenVestingProps {
   schedules: VestingSchedule[];
   onClaim?: (scheduleId: string) => void;
   claimingId?: string;
+  /** Show count badge next to the title */
+  showCount?: boolean;
+  /** Show progress bar labels (% vested / remaining) */
+  showProgressLabels?: boolean;
+  /** Show footer with schedules count */
+  showFooter?: boolean;
   className?: string;
 }

--- a/registry/w3-kit/transaction-history/transaction-history.tsx
+++ b/registry/w3-kit/transaction-history/transaction-history.tsx
@@ -101,7 +101,7 @@ export function TransactionHistory({
               {/* Description + hash */}
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {config.label}
+                  {tx.description ?? config.label}
                 </p>
                 <p className="font-mono text-xs text-gray-500 dark:text-gray-400">
                   {truncateHash(tx.hash)}

--- a/registry/w3-kit/transaction-history/types.ts
+++ b/registry/w3-kit/transaction-history/types.ts
@@ -7,6 +7,7 @@ export interface Transaction {
   from: string;
   to: string;
   timestamp: number;
+  description?: string;
 }
 
 export interface TransactionHistoryProps {


### PR DESCRIPTION
## Summary

Cherry-picked polish from #104 onto a fresh base. Adds optional props (footer counters, header badges, empty states, allocation/progress strips, tier-based color coding, etc.) across 22 registry components so they match the fidelity of the website preview demos.

All new props are optional with safe defaults; no breaking changes.

## Why not just merge #104

#104 was 11 days stale and would have regressed:

- main's bucket-grouping in `connect-wallet/connect-wallet.tsx` (added since #104 opened)
- the 5 shared PR workflows in `.github/workflows/`
- the tsconfig + eslint + error-cause fixes from #125
- recent dependency bumps (jest-dom, lucide-react, tailwind-merge, etc.)

This PR drops all those stale changes and keeps only the genuine component polish.

## Also includes

- `package.json`: add `chalk` and `commander` to root devDependencies so the `packages/create-w3-kit` subpackage build can resolve their type declarations. The subpackage already declares them as runtime deps; mirroring at root is the minimal fix without restructuring into npm workspaces. Fixes the build step on ui main's CI.

## Test plan

- [x] `npm install` succeeds
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors, 2 pre-existing warnings)
- [x] `npm run format:check` passes
- [x] `npm run build` passes (chalk fix verified)